### PR TITLE
#161290896 API Documentation Using Swagger

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,10 +3,14 @@ import bodyParser from 'body-parser';
 import cors from 'cors';
 import errorhandler from 'errorhandler';
 import morgan from 'morgan';
+import swaggerUi from 'swagger-ui-express';
 import routes from './server/src/routes';
-
+import swaggerDocument from './swagger.json';
 
 const isProduction = process.env.NODE_ENV;
+const options = {
+  explorer: true
+};
 
 // Create global app object
 const app = express();
@@ -19,6 +23,7 @@ app.use(bodyParser.json());
 
 app.use(cors());
 app.use(routes);
+app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(swaggerDocument, options));
 
 if (!isProduction) {
   app.use(errorhandler());

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "sequelize-cli": "^5.2.0",
     "sinon": "^7.1.1",
     "slug": "^0.9.2",
+    "swagger-ui-express": "^4.0.1",
     "underscore": "^1.9.1",
     "uuid": "^3.3.2",
     "winston": "^3.1.0",

--- a/swagger.json
+++ b/swagger.json
@@ -1,0 +1,243 @@
+{
+    "swagger": "2.0",
+     "info": {
+        "description": "A Social platform for the creative at heart. Creates a community of like minded authors to foster inspiration and innovation by leveraging the modern web",
+        "version": "1.0.0",
+        "title": "Authors Haven",
+        "contact": {
+          "email": "noldor.ah@gmail.com"
+        },
+        "license": {
+          "name": "MIT"
+        }
+      },
+      "host": "noldor-ah-backend-staging.herokuapp.com",
+      "basePath": "/api/v1",
+       "tags": [
+        {
+          "name": "users",
+          "description": "Users routes"
+        },
+        {
+          "name": "articles",
+          "description": "Articles routes"
+        },
+        {
+          "name": "comment",
+          "description": "Comment routes"
+        },
+        {
+          "name": "search",
+          "description": "Search articles route"
+        },
+        {
+          "name": "bookmark",
+          "description": "Bookmark an articles route"
+        },
+        {
+          "name": "category",
+          "description": "Category route"
+        },
+        {
+          "name": "highlight",
+          "description": "Highlight an article route"
+        },
+        {
+          "name": "reply",
+          "description": "Reply an article route"
+        }
+      ],
+      "schemes": [
+        "https"
+      ],
+      "paths": {
+        "/users/register": {
+          "post": {
+            "tags":["users"],
+            "summary": "Add a new user to Authors Haven",
+            "description": "Register a user",
+            "consumes": ["application/x-www-form-urlencoded"],
+            "produces" : ["application/json"],
+            "parameters": [ 
+              {
+                "name": "email",
+                "in": "formData",
+                "description": "Enter a valid email address",
+                "required": true,
+                "type": "string"
+              },
+              {
+                "name": "username",
+                "in": "formData",
+                "description": "Enter a username of your choice",
+                "required": true,
+                "type": "string"
+              },
+              {
+                "name": "password",
+                "in": "formData",
+                "description": "password must be at least 8 alpha-numeric characters",
+                "required": true,
+                "type": "string"
+              },
+              {
+                "name": "confirmPassword",
+                "in": "formData",
+                "description": "Enter the same password as above",
+                "required": true,
+                "type": "string"
+              }
+            ],
+            "responses": {
+              "200": {
+                "description": "successfully registered"
+              },
+              "409":{
+               "description": "Conflict with already exisiting data"
+              },
+              "400": {
+                "description": "Invalid parameter entered"
+              }
+            }
+              
+          }
+        },
+        "/users/login": {
+         "post": {
+           "tags":["users"],
+           "summary": "Log in registered user to Authors Haven",
+            "description": "Login a user",
+            "operationId": "loginUser",
+            "consumes": ["application/x-www-form-urlencoded"],
+            "produces" : ["application/json"],
+            "parameters": [
+                {
+                "name": "email",
+                "in": "formData",
+                "description": "Enter a valid email address",
+                "required": true,
+                "type": "string"
+              },
+                {
+                "name": "password",
+                "in": "formData",
+                "description": "Enter your password",
+                "required": true,
+                "type": "string"
+              }
+            ],
+            "responses": {
+              "200": {
+                "description": "Successfully logged in"
+              },
+              "400": {
+                "description": "invalid username or password"
+              },
+              "404": {
+                "description": "Email does not exist"
+              }
+            }
+         }
+        },
+        "/users": {
+            "get": {
+            "tags":["users"],
+           "summary": "View a list of users on Authors Haven",
+            "description": "Gets a list (id, username and email) of all registered users on Authos Haven. Only available to registered users",
+            "operationId": "getAllUsers",
+            "produces" : ["application/json"],
+            "parameters": [
+                {
+                    "name": "x-token",
+                    "in": "header",
+                    "description": "provide your token access",
+                    "required": true,
+                    "type": "string"
+                }
+            ],
+            "responses": {
+                "200": {
+                  "description": "successfully retrieved list"
+                },
+                "401": {
+                  "description": "invalid token"
+                }
+              }
+            }
+        },
+        "/users/forgot/": {
+          "put": {
+            "tags": ["users"],
+            "summary": "Request for a password reset",
+            "description": "Users can request to update their password",
+            "operationId": "forgotpassword",
+            "consumes": ["application/x-www-form-urlencoded"],
+            "produces" : ["application/json"],
+            "parameters": [
+              {
+                "name": "email",
+                "in": "formData",
+                "description": "Enter your email here",
+                "required": true,
+                "type": "string"
+              }
+            ],
+            "responses": {
+              "404": {
+                "description": "Email does not exist"
+              },
+              "200": {
+                "description" : "Check your email for further instruction"
+              }
+            }
+          }
+        },
+        "/users/forgot/{hash}": {
+          "post": {
+            "tags": ["users"],
+            "summary": "Resets the password with a provided hash",
+            "description": "Provide your new password to complete reset password process",
+            "operationId": "resetPassword",
+            "consumes": ["application/x-www-form-urlencoded"],
+            "produces" : ["application/json"],
+            "parameters": [
+            {
+            "in": "path",
+            "name": "hash",
+            "type": "string",
+              "required": true,
+              "description": "Copy the hash just after the /forgot/ route"
+            }, 
+            {
+                "name": "password",
+                "in": "formData",
+                "description": "Enter your password",
+                "required": true,
+                "type": "string"
+              },
+              {
+                "name": "confirmPassword",
+                "in": "formData",
+                "description": "Enter your password",
+                "required": true,
+                "type": "string"
+              }
+            ],
+            "responses": {
+              "401": {
+                "description": "invalid token"
+              },
+              "404": {
+                "description": "Email not found"
+              },
+              "503": {
+                "description": "password cannot be updated, try again"
+              },
+              "200": {
+                "description": "password has been updated"
+              }
+            }
+          }
+        }
+      }
+  }


### PR DESCRIPTION
#### What does this PR do?
- Implement API documentation using swagger
- Documents Users Login, Users Registration, Getting a list of registered users and Forgot Password Routes

#### Description of Task to be completed?
- `GET localhost://3000/api-docs`

#### How should this be manually tested?
- Upon cloning this repo, `cd` into it and install all the dependencies and dev dependencies by running `npm install` on the terminal.
- Start the server by running `npm run dev` and;
- Visit `localhost://3000/api-docs` to interact with the existing docs.

#### Any background context you want to provide?
N/A
#### What are the relevant pivotal tracker stories?
#161290896
#### Screenshots (if appropriate)
<img width="1440" alt="screen shot 2018-11-23 at 3 47 57 pm" src="https://user-images.githubusercontent.com/25327188/48949122-32d72380-ef37-11e8-9b1f-339fa0c5b97d.png">

#### Questions:
N/A