### PR TITLE
#161290908 Users Receive In-app and Email Notification

### DIFF
--- a/server/src/helpers/notification.js
+++ b/server/src/helpers/notification.js
@@ -13,6 +13,7 @@ const { Events, User, Article } = Models;
 class NotificationHelper {
   /**
      *@param {*} baseUrl baseUrl
+     *
      * @param {*} actionId  articleId
      * @param {*} actionType article/comment
      * @param {*} actorId   userId

--- a/server/src/helpers/templates.js
+++ b/server/src/helpers/templates.js
@@ -70,7 +70,6 @@ const verifyEmailTemplate = (username, baseUrl, hash) => {
   If you didn't sign up an account on Authors Haven please ignore this email</p><br>
   <span style="font-family:sans-serif;font-size:10px">&copy; 2018, Authors Haven</span>
 </div>`;
-
   return html;
 };
 

--- a/server/src/test/integration tests/notificationTest.js
+++ b/server/src/test/integration tests/notificationTest.js
@@ -1,0 +1,152 @@
+import chaiHttp from 'chai-http';
+import chai from 'chai';
+import app from '../../../../index';
+
+const { expect } = chai;
+chai.use(chaiHttp);
+
+const data = {};
+
+describe('Notifications', () => {
+  it('Register a user, ', (done) => {
+    const values = {
+      email: 'notify1@noldor.com',
+      username: 'notify1',
+      password: 'password123',
+      confirmPassword: 'password123'
+    };
+    chai.request(app)
+      .post('/api/v1/users/register')
+      .send(values)
+      .end((err, res) => {
+        if (err) done(err);
+        expect(res.status).to.equal(200);
+        expect(res.body).to.be.an('object');
+        expect(res.body.user.success).to.equal(true);
+        data.token = res.body.user.token;
+        done();
+      });
+  });
+  it('Register a user,2 ', (done) => {
+    const values = {
+      email: 'notify2@noldor.com',
+      username: 'notify2',
+      password: 'password123',
+      confirmPassword: 'password123'
+    };
+    chai.request(app)
+      .post('/api/v1/users/register')
+      .send(values)
+      .end((err, res) => {
+        if (err) done(err);
+        expect(res.status).to.equal(200);
+        expect(res.body).to.be.an('object');
+        expect(res.body.user.success).to.equal(true);
+        data.token2 = res.body.user.token;
+        done();
+      });
+  });
+
+  it('should return 200 to opt-out of notification', (done) => {
+    chai.request(app)
+      .put('/api/v1/users/notifications/opt')
+      .set('X-Token', data.token)
+      .end((error, response) => {
+        if (error) done(error);
+        expect(response.status).to.equal(200);
+        expect(response.body).to.be.an('object');
+        done();
+      });
+  });
+
+  it('should return 403 to get all notifications', (done) => {
+    chai.request(app)
+      .get('/api/v1/notifications')
+      .set('X-Token', data.token)
+      .end((error, response) => {
+        if (error) done(error);
+        expect(response.status).to.equal(403);
+        expect(response.body).to.be.an('object');
+        done();
+      });
+  });
+  it('should return 200 to opt-in of notification', (done) => {
+    chai.request(app)
+      .put('/api/v1/users/notifications/opt')
+      .set('X-Token', data.token)
+      .end((error, response) => {
+        if (error) done(error);
+        expect(response.status).to.equal(200);
+        expect(response.body).to.be.an('object');
+        done();
+      });
+  });
+
+  it('should return 404 to opt-in of notification', (done) => {
+    chai.request(app)
+      .get('/api/v1/notifications')
+      .set('X-Token', data.token)
+      .end((error, response) => {
+        if (error) done(error);
+        expect(response.status).to.equal(404);
+        expect(response.body).to.be.an('object');
+        done();
+      });
+  });
+
+  it('should return 201 for notify2 follows notify 1', (done) => {
+    chai.request(app)
+      .post('/api/v1/users/notify1/follow')
+      .set('X-Token', data.token2)
+      .end((error, response) => {
+        if (error) done(error);
+        expect(response.status).to.equal(201);
+        expect(response.body).to.be.an('object');
+        done();
+      });
+  });
+
+  it('should return 201 if article is added successfully', (done) => {
+    chai.request(app)
+      .post('/api/v1/articles')
+      .set('X-Token', data.token)
+      .send({
+        title: 'this is the title',
+        description: 'this is the description',
+        content: 'this is the content',
+        featuredImg: 'ahghgkjag.jpg',
+        tags: 'bars,foos,philosophical,smart'
+
+      })
+      .end((error, response) => {
+        if (error) done(error);
+        expect(response.status).to.equal(201);
+        expect(response.body).to.be.an('object');
+        data.slug = response.body.article.slug;
+        done();
+      });
+  });
+  it('should return a 201', (done) => {
+    chai.request(app)
+      .put(`/api/v1/articles/${data.slug}/publish`)
+      .set('X-Token', data.token)
+      .end((error, response) => {
+        if (error) done(error);
+        expect(response.status).to.equal(200);
+        expect(response.body).to.be.an('object');
+        done();
+      });
+  });
+
+  it('should return 200 to opt-in of notification', (done) => {
+    chai.request(app)
+      .get('/api/v1/notifications')
+      .set('X-Token', data.token2)
+      .end((error, response) => {
+        if (error) done(error);
+        expect(response.status).to.equal(200);
+        expect(response.body).to.be.an('object');
+        done();
+      });
+  });
+});


### PR DESCRIPTION
#### What does this PR do?
Enables users to receive in-app notifications and email notifications.
#### Description of Task to be completed?
  -  unit tests for email notification
  -  email notification using node mailer
  -  create migration of events and notification
  -  create events model and association
  -  create notification helpers for adding notification
  -  create route and controller for getting an in-app notification
  -  create an endpoint for notification opt-in and opt-out
  -  add notification worker to after article is published
  
#### How should this be manually tested?
- Create an account on the platform by following this instruction #11 
- Follow an Author on the platform by following this instruction #26 
- Following an Author allows a user to get notified when on the app or via Email when the Author posts an article
- If an Author, follow this instruction to post an article #13 
- Users can also get notifications on articles they like. To like an article, follow this instruction #18 

The route to get notifications (Read and Unread) - `/api/v1/notifications`
The route to opt-out or opt-in for notification - `/api/v1/users/notifications/opt/`

#### Any background context you want to provide?
A user must be logged in to access these routes

#### What are the relevant pivotal tracker stories?
#161290908

#### Screenshots (if appropriate)
<img width="1091" alt="screen shot 2018-11-26 at 3 45 43 pm" src="https://user-images.githubusercontent.com/25327188/49021205-65c92380-f192-11e8-982c-5df4dc2dd3b3.png">

#### Questions:
N/A