### PR TITLE
#162150225 Enable deactivated user to reactivate

### DIFF
--- a/logs/error.log
+++ b/logs/error.log
@@ -1230,7 +1230,11 @@
 [Sun Nov 25 2018 02:38:32 GMT+0100 (WAT)] : 'This is just an error logger test'
 [Sun Nov 25 2018 02:38:32 GMT+0100 (WAT)] : 'This is just an error logger test'
 [Sun Nov 25 2018 02:38:32 GMT+0100 (WAT)] : 'This is just an error logger test'
+<<<<<<< HEAD
 [Tue Nov 27 2018 18:15:51 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:21:48 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -1248,7 +1252,11 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Tue Nov 27 2018 18:15:51 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:21:48 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -1266,7 +1274,11 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Tue Nov 27 2018 18:15:51 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:21:48 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -1284,7 +1296,11 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Tue Nov 27 2018 18:15:51 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:21:48 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -1302,7 +1318,11 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Tue Nov 27 2018 18:15:52 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:21:48 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -1320,7 +1340,11 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Tue Nov 27 2018 18:15:52 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:21:48 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -1338,7 +1362,11 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Tue Nov 27 2018 18:15:52 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:21:49 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -1356,7 +1384,11 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Tue Nov 27 2018 18:15:52 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:21:49 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -1374,7 +1406,11 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Tue Nov 27 2018 18:15:52 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:21:49 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -1392,7 +1428,11 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Tue Nov 27 2018 18:15:52 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:21:49 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -1410,7 +1450,11 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Tue Nov 27 2018 18:15:52 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:21:49 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -1428,7 +1472,11 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Tue Nov 27 2018 18:15:53 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:21:49 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -1446,7 +1494,11 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Tue Nov 27 2018 18:15:53 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:21:49 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -1464,7 +1516,11 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Tue Nov 27 2018 18:15:54 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:21:50 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -1482,7 +1538,11 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Tue Nov 27 2018 18:15:54 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:21:51 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -1500,7 +1560,11 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Tue Nov 27 2018 18:15:54 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:21:51 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -1518,7 +1582,11 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Tue Nov 27 2018 18:15:54 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:21:51 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -1536,7 +1604,11 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Tue Nov 27 2018 18:15:54 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:21:51 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -1554,7 +1626,11 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Tue Nov 27 2018 18:15:54 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:21:51 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -1572,7 +1648,11 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Tue Nov 27 2018 18:15:54 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:21:51 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -1590,7 +1670,14 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Tue Nov 27 2018 18:15:55 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:21:51 GMT+0100 (WAT)] : 'This is just an error logger test'
+[Wed Nov 28 2018 18:21:51 GMT+0100 (WAT)] : 'This is just an error logger test'
+[Wed Nov 28 2018 18:21:51 GMT+0100 (WAT)] : 'This is just an error logger test'
+[Wed Nov 28 2018 18:29:27 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -1608,10 +1695,14 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Tue Nov 27 2018 18:15:55 GMT+0100 (WAT)] : 'This is just an error logger test'
 [Tue Nov 27 2018 18:15:55 GMT+0100 (WAT)] : 'This is just an error logger test'
 [Tue Nov 27 2018 18:15:55 GMT+0100 (WAT)] : 'This is just an error logger test'
 [Tue Nov 27 2018 18:15:55 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:29:27 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -1629,7 +1720,11 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Tue Nov 27 2018 18:15:55 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:29:27 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -1647,7 +1742,11 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Tue Nov 27 2018 18:15:55 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:29:27 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -1665,7 +1764,11 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Tue Nov 27 2018 18:15:55 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:29:27 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -1683,7 +1786,11 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Tue Nov 27 2018 18:15:55 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:29:28 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -1701,7 +1808,11 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Tue Nov 27 2018 18:15:55 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:29:28 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -1719,7 +1830,11 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Tue Nov 27 2018 18:17:58 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:29:28 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -1737,7 +1852,11 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Tue Nov 27 2018 18:17:58 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:29:28 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -1755,7 +1874,11 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Tue Nov 27 2018 18:17:58 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:29:28 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -1773,7 +1896,11 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Tue Nov 27 2018 18:17:59 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:29:28 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -1791,7 +1918,11 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Tue Nov 27 2018 18:17:59 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:29:29 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -1809,7 +1940,11 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Tue Nov 27 2018 18:17:59 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:29:29 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -1827,7 +1962,11 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Tue Nov 27 2018 18:17:59 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:29:30 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -1845,7 +1984,11 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Tue Nov 27 2018 18:18:00 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:29:30 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -1863,7 +2006,11 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Tue Nov 27 2018 18:18:00 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:29:30 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -1881,7 +2028,11 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Tue Nov 27 2018 18:18:00 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:29:30 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -1899,7 +2050,11 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Tue Nov 27 2018 18:18:00 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:29:30 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -1917,7 +2072,11 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Tue Nov 27 2018 18:18:00 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:29:30 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -1935,7 +2094,11 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Tue Nov 27 2018 18:18:00 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:29:30 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -1953,7 +2116,14 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Tue Nov 27 2018 18:18:01 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:29:30 GMT+0100 (WAT)] : 'This is just an error logger test'
+[Wed Nov 28 2018 18:29:30 GMT+0100 (WAT)] : 'This is just an error logger test'
+[Wed Nov 28 2018 18:29:30 GMT+0100 (WAT)] : 'This is just an error logger test'
+[Wed Nov 28 2018 18:29:30 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -1971,7 +2141,11 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Tue Nov 27 2018 18:18:01 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:30:46 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -1989,7 +2163,11 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Tue Nov 27 2018 18:18:02 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:30:46 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -2007,7 +2185,11 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Tue Nov 27 2018 18:18:02 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:30:46 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -2025,7 +2207,11 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Tue Nov 27 2018 18:18:02 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:30:47 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -2043,7 +2229,11 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Tue Nov 27 2018 18:18:02 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:30:47 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -2061,10 +2251,14 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Tue Nov 27 2018 18:18:02 GMT+0100 (WAT)] : 'This is just an error logger test'
 [Tue Nov 27 2018 18:18:02 GMT+0100 (WAT)] : 'This is just an error logger test'
 [Tue Nov 27 2018 18:18:02 GMT+0100 (WAT)] : 'This is just an error logger test'
 [Tue Nov 27 2018 18:18:02 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:30:47 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -2082,7 +2276,11 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Tue Nov 27 2018 18:18:02 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:30:47 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -2100,7 +2298,11 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Tue Nov 27 2018 18:18:02 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:30:48 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -2118,7 +2320,11 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Tue Nov 27 2018 18:18:02 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:30:48 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -2136,7 +2342,11 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Tue Nov 27 2018 18:18:02 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:30:48 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -2154,7 +2364,11 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Tue Nov 27 2018 18:18:02 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:30:48 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -2172,7 +2386,11 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Tue Nov 27 2018 18:18:02 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:30:48 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -2190,7 +2408,11 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Tue Nov 27 2018 18:18:02 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:30:48 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -2208,7 +2430,11 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Tue Nov 27 2018 18:18:55 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:30:50 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -2226,7 +2452,11 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Tue Nov 27 2018 18:18:55 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:30:50 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -2244,7 +2474,11 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Tue Nov 27 2018 18:18:55 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:30:50 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -2262,7 +2496,11 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Tue Nov 27 2018 18:18:56 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:30:50 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -2280,7 +2518,11 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Tue Nov 27 2018 18:18:56 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:30:50 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -2298,7 +2540,11 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Tue Nov 27 2018 18:18:56 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:30:50 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -2316,7 +2562,11 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Tue Nov 27 2018 18:18:56 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:30:51 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -2334,7 +2584,11 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Tue Nov 27 2018 18:18:57 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:30:51 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -2352,7 +2606,14 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Tue Nov 27 2018 18:18:57 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:30:51 GMT+0100 (WAT)] : 'This is just an error logger test'
+[Wed Nov 28 2018 18:30:51 GMT+0100 (WAT)] : 'This is just an error logger test'
+[Wed Nov 28 2018 18:30:51 GMT+0100 (WAT)] : 'This is just an error logger test'
+[Wed Nov 28 2018 18:45:49 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -2370,7 +2631,11 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Tue Nov 27 2018 18:18:57 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:45:49 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -2388,7 +2653,11 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Tue Nov 27 2018 18:18:57 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:45:49 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -2406,7 +2675,11 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Tue Nov 27 2018 18:18:57 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:45:50 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -2424,7 +2697,11 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Tue Nov 27 2018 18:18:57 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:45:50 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -2442,7 +2719,11 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Tue Nov 27 2018 18:18:58 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:45:50 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -2460,7 +2741,11 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Tue Nov 27 2018 18:18:58 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:45:50 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -2478,7 +2763,11 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Tue Nov 27 2018 18:18:58 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:45:51 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -2496,7 +2785,11 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Tue Nov 27 2018 18:18:58 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:45:51 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -2514,7 +2807,11 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Tue Nov 27 2018 18:18:58 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:45:51 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -2532,7 +2829,11 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Tue Nov 27 2018 18:18:58 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:45:51 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -2550,7 +2851,11 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Tue Nov 27 2018 18:18:59 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:45:52 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -2568,7 +2873,11 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Tue Nov 27 2018 18:18:59 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:45:52 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -2586,10 +2895,14 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Tue Nov 27 2018 18:18:59 GMT+0100 (WAT)] : 'This is just an error logger test'
 [Tue Nov 27 2018 18:18:59 GMT+0100 (WAT)] : 'This is just an error logger test'
 [Tue Nov 27 2018 18:18:59 GMT+0100 (WAT)] : 'This is just an error logger test'
 [Tue Nov 27 2018 18:18:59 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:45:53 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -2607,7 +2920,11 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Tue Nov 27 2018 18:18:59 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:45:53 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -2625,7 +2942,11 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Tue Nov 27 2018 18:18:59 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:45:53 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -2643,7 +2964,11 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Tue Nov 27 2018 18:18:59 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:45:53 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -2661,7 +2986,11 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Tue Nov 27 2018 18:18:59 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:45:53 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -2679,7 +3008,11 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Tue Nov 27 2018 18:18:59 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:45:53 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -2697,7 +3030,14 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Wed Nov 28 2018 12:43:33 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:45:53 GMT+0100 (WAT)] : 'This is just an error logger test'
+[Wed Nov 28 2018 18:45:53 GMT+0100 (WAT)] : 'This is just an error logger test'
+[Wed Nov 28 2018 18:45:53 GMT+0100 (WAT)] : 'This is just an error logger test'
+[Wed Nov 28 2018 18:48:05 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -2715,7 +3055,11 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Wed Nov 28 2018 14:55:54 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:48:05 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -2733,7 +3077,11 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Wed Nov 28 2018 14:55:54 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:48:05 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -2751,7 +3099,11 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Wed Nov 28 2018 14:55:54 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:48:06 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -2769,7 +3121,11 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Wed Nov 28 2018 14:55:55 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:48:06 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -2787,7 +3143,11 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Wed Nov 28 2018 14:55:55 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:48:06 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -2805,7 +3165,11 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Wed Nov 28 2018 14:55:55 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:48:06 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -2823,7 +3187,11 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Wed Nov 28 2018 14:55:55 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:48:07 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -2841,7 +3209,11 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Wed Nov 28 2018 14:55:56 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:48:07 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -2859,7 +3231,11 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Wed Nov 28 2018 14:55:56 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:48:07 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -2877,7 +3253,11 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Wed Nov 28 2018 14:55:56 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:48:07 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -2895,7 +3275,11 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Wed Nov 28 2018 14:55:56 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:48:07 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -2913,7 +3297,11 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Wed Nov 28 2018 14:55:56 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:48:07 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -2931,7 +3319,11 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Wed Nov 28 2018 14:55:56 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:48:08 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -2949,7 +3341,11 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Wed Nov 28 2018 14:55:57 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:48:08 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -2967,7 +3363,11 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Wed Nov 28 2018 14:55:57 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:48:09 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -2985,7 +3385,11 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Wed Nov 28 2018 14:55:58 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:48:09 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -3003,7 +3407,11 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Wed Nov 28 2018 14:55:58 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:48:09 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -3021,7 +3429,11 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Wed Nov 28 2018 14:55:58 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:48:09 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -3039,7 +3451,11 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Wed Nov 28 2018 14:55:58 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:48:09 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -3057,7 +3473,14 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Wed Nov 28 2018 14:55:58 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:48:09 GMT+0100 (WAT)] : 'This is just an error logger test'
+[Wed Nov 28 2018 18:48:09 GMT+0100 (WAT)] : 'This is just an error logger test'
+[Wed Nov 28 2018 18:48:09 GMT+0100 (WAT)] : 'This is just an error logger test'
+[Wed Nov 28 2018 18:48:09 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -3075,7 +3498,11 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Wed Nov 28 2018 14:55:58 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:48:31 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -3093,10 +3520,14 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Wed Nov 28 2018 14:55:58 GMT+0100 (WAT)] : 'This is just an error logger test'
 [Wed Nov 28 2018 14:55:58 GMT+0100 (WAT)] : 'This is just an error logger test'
 [Wed Nov 28 2018 14:55:58 GMT+0100 (WAT)] : 'This is just an error logger test'
 [Wed Nov 28 2018 14:55:58 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:48:31 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -3114,7 +3545,11 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Wed Nov 28 2018 14:55:58 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:48:31 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -3132,7 +3567,11 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Wed Nov 28 2018 14:55:58 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:48:31 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -3150,7 +3589,11 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Wed Nov 28 2018 14:55:59 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:48:31 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -3168,7 +3611,11 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Wed Nov 28 2018 14:55:59 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:48:31 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -3186,7 +3633,11 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Wed Nov 28 2018 14:55:59 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:48:32 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -3204,7 +3655,11 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Wed Nov 28 2018 14:56:25 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:48:32 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -3222,7 +3677,11 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Wed Nov 28 2018 14:56:25 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:48:32 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -3240,7 +3699,11 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Wed Nov 28 2018 14:56:25 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:48:32 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -3258,7 +3721,11 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Wed Nov 28 2018 14:56:26 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:48:32 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -3276,7 +3743,11 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Wed Nov 28 2018 14:56:26 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:48:32 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -3294,7 +3765,11 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Wed Nov 28 2018 14:56:26 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:48:33 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -3312,7 +3787,11 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Wed Nov 28 2018 14:56:26 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:48:34 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -3330,7 +3809,11 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Wed Nov 28 2018 14:56:27 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:48:34 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -3348,7 +3831,11 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Wed Nov 28 2018 14:56:27 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:48:34 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -3366,7 +3853,11 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Wed Nov 28 2018 14:56:27 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:48:34 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -3384,7 +3875,11 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Wed Nov 28 2018 14:56:27 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:48:34 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -3402,7 +3897,11 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Wed Nov 28 2018 14:56:27 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:48:34 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -3420,7 +3919,11 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Wed Nov 28 2018 14:56:27 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:48:34 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -3438,7 +3941,11 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Wed Nov 28 2018 14:56:28 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:48:35 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -3456,7 +3963,14 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Wed Nov 28 2018 14:56:29 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:48:35 GMT+0100 (WAT)] : 'This is just an error logger test'
+[Wed Nov 28 2018 18:48:35 GMT+0100 (WAT)] : 'This is just an error logger test'
+[Wed Nov 28 2018 18:48:35 GMT+0100 (WAT)] : 'This is just an error logger test'
+[Wed Nov 28 2018 18:48:35 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -3474,7 +3988,11 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Wed Nov 28 2018 14:56:29 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:49:08 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -3492,7 +4010,11 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Wed Nov 28 2018 14:56:29 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:49:08 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -3510,7 +4032,11 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Wed Nov 28 2018 14:56:29 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:49:08 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -3528,7 +4054,11 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Wed Nov 28 2018 14:56:29 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:49:08 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -3546,7 +4076,11 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Wed Nov 28 2018 14:56:29 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:49:09 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -3564,7 +4098,11 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Wed Nov 28 2018 14:56:30 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:49:09 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -3582,10 +4120,14 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Wed Nov 28 2018 14:56:30 GMT+0100 (WAT)] : 'This is just an error logger test'
 [Wed Nov 28 2018 14:56:30 GMT+0100 (WAT)] : 'This is just an error logger test'
 [Wed Nov 28 2018 14:56:30 GMT+0100 (WAT)] : 'This is just an error logger test'
 [Wed Nov 28 2018 14:56:30 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:49:09 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -3603,7 +4145,11 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Wed Nov 28 2018 14:56:30 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:49:09 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -3621,7 +4167,11 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Wed Nov 28 2018 14:56:30 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:49:09 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -3639,7 +4189,11 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Wed Nov 28 2018 14:56:30 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:49:10 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -3657,7 +4211,11 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Wed Nov 28 2018 14:56:30 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:49:10 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -3675,7 +4233,11 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Wed Nov 28 2018 14:56:30 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:49:10 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -3693,7 +4255,11 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Thu Nov 29 2018 16:25:22 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:49:10 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -3711,7 +4277,11 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Thu Nov 29 2018 16:25:22 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:49:11 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -3729,7 +4299,11 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Thu Nov 29 2018 16:25:22 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:49:11 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -3747,7 +4321,11 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Thu Nov 29 2018 16:25:23 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:49:11 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -3765,7 +4343,11 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Thu Nov 29 2018 16:25:23 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:49:11 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -3783,7 +4365,11 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Thu Nov 29 2018 16:25:23 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:49:11 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -3801,7 +4387,11 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Thu Nov 29 2018 16:25:23 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:49:11 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -3819,7 +4409,11 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Thu Nov 29 2018 16:25:23 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:49:12 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -3837,7 +4431,11 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Thu Nov 29 2018 16:25:23 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:49:12 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -3855,7 +4453,14 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Thu Nov 29 2018 16:25:24 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:49:12 GMT+0100 (WAT)] : 'This is just an error logger test'
+[Wed Nov 28 2018 18:49:12 GMT+0100 (WAT)] : 'This is just an error logger test'
+[Wed Nov 28 2018 18:49:12 GMT+0100 (WAT)] : 'This is just an error logger test'
+[Wed Nov 28 2018 18:50:04 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -3873,7 +4478,11 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Thu Nov 29 2018 16:25:24 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:50:04 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -3891,7 +4500,11 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Thu Nov 29 2018 16:25:24 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:50:04 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -3909,7 +4522,11 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Thu Nov 29 2018 16:25:24 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:50:04 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -3927,7 +4544,11 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Thu Nov 29 2018 16:25:25 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:50:05 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -3945,7 +4566,11 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Thu Nov 29 2018 16:25:25 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:50:05 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -3963,7 +4588,11 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Thu Nov 29 2018 16:25:25 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:50:05 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -3981,7 +4610,11 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Thu Nov 29 2018 16:25:25 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:50:05 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -3999,7 +4632,11 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Thu Nov 29 2018 16:25:25 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:50:05 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -4017,7 +4654,11 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Thu Nov 29 2018 16:25:25 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:50:05 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -4035,10 +4676,14 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Thu Nov 29 2018 16:25:25 GMT+0100 (WAT)] : 'This is just an error logger test'
 [Thu Nov 29 2018 16:25:25 GMT+0100 (WAT)] : 'This is just an error logger test'
 [Thu Nov 29 2018 16:25:25 GMT+0100 (WAT)] : 'This is just an error logger test'
 [Thu Nov 29 2018 16:25:25 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:50:06 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -4056,7 +4701,11 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Thu Nov 29 2018 16:25:26 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:50:06 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -4074,7 +4723,11 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Thu Nov 29 2018 16:25:26 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:50:06 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -4092,7 +4745,11 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Thu Nov 29 2018 16:25:26 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:50:07 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -4110,7 +4767,11 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Thu Nov 29 2018 16:25:26 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:50:07 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -4128,7 +4789,11 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Thu Nov 29 2018 16:25:26 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:50:07 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -4146,7 +4811,11 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Thu Nov 29 2018 16:25:26 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:50:07 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
@@ -4164,7 +4833,1322 @@
     at readableAddChunk (_stream_readable.js:250:11)
     at TLSSocket.Readable.push (_stream_readable.js:208:10)
     at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
 [Thu Nov 29 2018 16:25:26 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+=======
+[Wed Nov 28 2018 18:50:07 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+>>>>>>> bug(reactivate user): Allow user reactivate account
+    at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
+    at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
+    at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
+    at SMTPConnection.once (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:188:17)
+    at Object.onceWrapper (events.js:313:30)
+    at emitNone (events.js:106:13)
+    at SMTPConnection.emit (events.js:208:7)
+    at SMTPConnection._actionEHLO (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:1133:14)
+    at SMTPConnection._processResponse (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:764:20)
+    at SMTPConnection._onData (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:570:14)
+    at TLSSocket._socket.on.chunk (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:522:47)
+    at emitOne (events.js:116:13)
+    at TLSSocket.emit (events.js:211:7)
+    at addChunk (_stream_readable.js:263:12)
+    at readableAddChunk (_stream_readable.js:250:11)
+    at TLSSocket.Readable.push (_stream_readable.js:208:10)
+    at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+<<<<<<< HEAD
+=======
+[Wed Nov 28 2018 18:50:07 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+    at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
+    at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
+    at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
+    at SMTPConnection.once (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:188:17)
+    at Object.onceWrapper (events.js:313:30)
+    at emitNone (events.js:106:13)
+    at SMTPConnection.emit (events.js:208:7)
+    at SMTPConnection._actionEHLO (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:1133:14)
+    at SMTPConnection._processResponse (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:764:20)
+    at SMTPConnection._onData (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:570:14)
+    at TLSSocket._socket.on.chunk (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:522:47)
+    at emitOne (events.js:116:13)
+    at TLSSocket.emit (events.js:211:7)
+    at addChunk (_stream_readable.js:263:12)
+    at readableAddChunk (_stream_readable.js:250:11)
+    at TLSSocket.Readable.push (_stream_readable.js:208:10)
+    at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+[Wed Nov 28 2018 18:50:08 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+    at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
+    at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
+    at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
+    at SMTPConnection.once (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:188:17)
+    at Object.onceWrapper (events.js:313:30)
+    at emitNone (events.js:106:13)
+    at SMTPConnection.emit (events.js:208:7)
+    at SMTPConnection._actionEHLO (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:1133:14)
+    at SMTPConnection._processResponse (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:764:20)
+    at SMTPConnection._onData (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:570:14)
+    at TLSSocket._socket.on.chunk (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:522:47)
+    at emitOne (events.js:116:13)
+    at TLSSocket.emit (events.js:211:7)
+    at addChunk (_stream_readable.js:263:12)
+    at readableAddChunk (_stream_readable.js:250:11)
+    at TLSSocket.Readable.push (_stream_readable.js:208:10)
+    at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+[Wed Nov 28 2018 18:50:08 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+    at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
+    at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
+    at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
+    at SMTPConnection.once (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:188:17)
+    at Object.onceWrapper (events.js:313:30)
+    at emitNone (events.js:106:13)
+    at SMTPConnection.emit (events.js:208:7)
+    at SMTPConnection._actionEHLO (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:1133:14)
+    at SMTPConnection._processResponse (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:764:20)
+    at SMTPConnection._onData (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:570:14)
+    at TLSSocket._socket.on.chunk (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:522:47)
+    at emitOne (events.js:116:13)
+    at TLSSocket.emit (events.js:211:7)
+    at addChunk (_stream_readable.js:263:12)
+    at readableAddChunk (_stream_readable.js:250:11)
+    at TLSSocket.Readable.push (_stream_readable.js:208:10)
+    at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+[Wed Nov 28 2018 18:50:08 GMT+0100 (WAT)] : 'This is just an error logger test'
+[Wed Nov 28 2018 18:50:08 GMT+0100 (WAT)] : 'This is just an error logger test'
+[Wed Nov 28 2018 18:50:08 GMT+0100 (WAT)] : 'This is just an error logger test'
+[Wed Nov 28 2018 18:51:43 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+    at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
+    at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
+    at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
+    at SMTPConnection.once (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:188:17)
+    at Object.onceWrapper (events.js:313:30)
+    at emitNone (events.js:106:13)
+    at SMTPConnection.emit (events.js:208:7)
+    at SMTPConnection._actionEHLO (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:1133:14)
+    at SMTPConnection._processResponse (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:764:20)
+    at SMTPConnection._onData (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:570:14)
+    at TLSSocket._socket.on.chunk (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:522:47)
+    at emitOne (events.js:116:13)
+    at TLSSocket.emit (events.js:211:7)
+    at addChunk (_stream_readable.js:263:12)
+    at readableAddChunk (_stream_readable.js:250:11)
+    at TLSSocket.Readable.push (_stream_readable.js:208:10)
+    at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+[Wed Nov 28 2018 18:51:43 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+    at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
+    at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
+    at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
+    at SMTPConnection.once (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:188:17)
+    at Object.onceWrapper (events.js:313:30)
+    at emitNone (events.js:106:13)
+    at SMTPConnection.emit (events.js:208:7)
+    at SMTPConnection._actionEHLO (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:1133:14)
+    at SMTPConnection._processResponse (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:764:20)
+    at SMTPConnection._onData (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:570:14)
+    at TLSSocket._socket.on.chunk (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:522:47)
+    at emitOne (events.js:116:13)
+    at TLSSocket.emit (events.js:211:7)
+    at addChunk (_stream_readable.js:263:12)
+    at readableAddChunk (_stream_readable.js:250:11)
+    at TLSSocket.Readable.push (_stream_readable.js:208:10)
+    at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+[Wed Nov 28 2018 18:51:43 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+    at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
+    at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
+    at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
+    at SMTPConnection.once (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:188:17)
+    at Object.onceWrapper (events.js:313:30)
+    at emitNone (events.js:106:13)
+    at SMTPConnection.emit (events.js:208:7)
+    at SMTPConnection._actionEHLO (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:1133:14)
+    at SMTPConnection._processResponse (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:764:20)
+    at SMTPConnection._onData (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:570:14)
+    at TLSSocket._socket.on.chunk (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:522:47)
+    at emitOne (events.js:116:13)
+    at TLSSocket.emit (events.js:211:7)
+    at addChunk (_stream_readable.js:263:12)
+    at readableAddChunk (_stream_readable.js:250:11)
+    at TLSSocket.Readable.push (_stream_readable.js:208:10)
+    at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+[Wed Nov 28 2018 18:51:43 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+    at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
+    at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
+    at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
+    at SMTPConnection.once (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:188:17)
+    at Object.onceWrapper (events.js:313:30)
+    at emitNone (events.js:106:13)
+    at SMTPConnection.emit (events.js:208:7)
+    at SMTPConnection._actionEHLO (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:1133:14)
+    at SMTPConnection._processResponse (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:764:20)
+    at SMTPConnection._onData (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:570:14)
+    at TLSSocket._socket.on.chunk (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:522:47)
+    at emitOne (events.js:116:13)
+    at TLSSocket.emit (events.js:211:7)
+    at addChunk (_stream_readable.js:263:12)
+    at readableAddChunk (_stream_readable.js:250:11)
+    at TLSSocket.Readable.push (_stream_readable.js:208:10)
+    at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+[Wed Nov 28 2018 18:51:43 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+    at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
+    at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
+    at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
+    at SMTPConnection.once (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:188:17)
+    at Object.onceWrapper (events.js:313:30)
+    at emitNone (events.js:106:13)
+    at SMTPConnection.emit (events.js:208:7)
+    at SMTPConnection._actionEHLO (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:1133:14)
+    at SMTPConnection._processResponse (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:764:20)
+    at SMTPConnection._onData (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:570:14)
+    at TLSSocket._socket.on.chunk (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:522:47)
+    at emitOne (events.js:116:13)
+    at TLSSocket.emit (events.js:211:7)
+    at addChunk (_stream_readable.js:263:12)
+    at readableAddChunk (_stream_readable.js:250:11)
+    at TLSSocket.Readable.push (_stream_readable.js:208:10)
+    at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+[Wed Nov 28 2018 18:51:43 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+    at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
+    at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
+    at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
+    at SMTPConnection.once (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:188:17)
+    at Object.onceWrapper (events.js:313:30)
+    at emitNone (events.js:106:13)
+    at SMTPConnection.emit (events.js:208:7)
+    at SMTPConnection._actionEHLO (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:1133:14)
+    at SMTPConnection._processResponse (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:764:20)
+    at SMTPConnection._onData (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:570:14)
+    at TLSSocket._socket.on.chunk (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:522:47)
+    at emitOne (events.js:116:13)
+    at TLSSocket.emit (events.js:211:7)
+    at addChunk (_stream_readable.js:263:12)
+    at readableAddChunk (_stream_readable.js:250:11)
+    at TLSSocket.Readable.push (_stream_readable.js:208:10)
+    at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+[Wed Nov 28 2018 18:51:44 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+    at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
+    at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
+    at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
+    at SMTPConnection.once (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:188:17)
+    at Object.onceWrapper (events.js:313:30)
+    at emitNone (events.js:106:13)
+    at SMTPConnection.emit (events.js:208:7)
+    at SMTPConnection._actionEHLO (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:1133:14)
+    at SMTPConnection._processResponse (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:764:20)
+    at SMTPConnection._onData (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:570:14)
+    at TLSSocket._socket.on.chunk (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:522:47)
+    at emitOne (events.js:116:13)
+    at TLSSocket.emit (events.js:211:7)
+    at addChunk (_stream_readable.js:263:12)
+    at readableAddChunk (_stream_readable.js:250:11)
+    at TLSSocket.Readable.push (_stream_readable.js:208:10)
+    at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+[Wed Nov 28 2018 18:51:44 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+    at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
+    at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
+    at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
+    at SMTPConnection.once (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:188:17)
+    at Object.onceWrapper (events.js:313:30)
+    at emitNone (events.js:106:13)
+    at SMTPConnection.emit (events.js:208:7)
+    at SMTPConnection._actionEHLO (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:1133:14)
+    at SMTPConnection._processResponse (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:764:20)
+    at SMTPConnection._onData (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:570:14)
+    at TLSSocket._socket.on.chunk (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:522:47)
+    at emitOne (events.js:116:13)
+    at TLSSocket.emit (events.js:211:7)
+    at addChunk (_stream_readable.js:263:12)
+    at readableAddChunk (_stream_readable.js:250:11)
+    at TLSSocket.Readable.push (_stream_readable.js:208:10)
+    at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+[Wed Nov 28 2018 18:51:44 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+    at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
+    at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
+    at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
+    at SMTPConnection.once (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:188:17)
+    at Object.onceWrapper (events.js:313:30)
+    at emitNone (events.js:106:13)
+    at SMTPConnection.emit (events.js:208:7)
+    at SMTPConnection._actionEHLO (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:1133:14)
+    at SMTPConnection._processResponse (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:764:20)
+    at SMTPConnection._onData (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:570:14)
+    at TLSSocket._socket.on.chunk (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:522:47)
+    at emitOne (events.js:116:13)
+    at TLSSocket.emit (events.js:211:7)
+    at addChunk (_stream_readable.js:263:12)
+    at readableAddChunk (_stream_readable.js:250:11)
+    at TLSSocket.Readable.push (_stream_readable.js:208:10)
+    at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+[Wed Nov 28 2018 18:51:44 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+    at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
+    at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
+    at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
+    at SMTPConnection.once (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:188:17)
+    at Object.onceWrapper (events.js:313:30)
+    at emitNone (events.js:106:13)
+    at SMTPConnection.emit (events.js:208:7)
+    at SMTPConnection._actionEHLO (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:1133:14)
+    at SMTPConnection._processResponse (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:764:20)
+    at SMTPConnection._onData (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:570:14)
+    at TLSSocket._socket.on.chunk (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:522:47)
+    at emitOne (events.js:116:13)
+    at TLSSocket.emit (events.js:211:7)
+    at addChunk (_stream_readable.js:263:12)
+    at readableAddChunk (_stream_readable.js:250:11)
+    at TLSSocket.Readable.push (_stream_readable.js:208:10)
+    at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+[Wed Nov 28 2018 18:51:44 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+    at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
+    at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
+    at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
+    at SMTPConnection.once (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:188:17)
+    at Object.onceWrapper (events.js:313:30)
+    at emitNone (events.js:106:13)
+    at SMTPConnection.emit (events.js:208:7)
+    at SMTPConnection._actionEHLO (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:1133:14)
+    at SMTPConnection._processResponse (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:764:20)
+    at SMTPConnection._onData (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:570:14)
+    at TLSSocket._socket.on.chunk (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:522:47)
+    at emitOne (events.js:116:13)
+    at TLSSocket.emit (events.js:211:7)
+    at addChunk (_stream_readable.js:263:12)
+    at readableAddChunk (_stream_readable.js:250:11)
+    at TLSSocket.Readable.push (_stream_readable.js:208:10)
+    at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+[Wed Nov 28 2018 18:51:44 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+    at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
+    at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
+    at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
+    at SMTPConnection.once (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:188:17)
+    at Object.onceWrapper (events.js:313:30)
+    at emitNone (events.js:106:13)
+    at SMTPConnection.emit (events.js:208:7)
+    at SMTPConnection._actionEHLO (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:1133:14)
+    at SMTPConnection._processResponse (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:764:20)
+    at SMTPConnection._onData (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:570:14)
+    at TLSSocket._socket.on.chunk (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:522:47)
+    at emitOne (events.js:116:13)
+    at TLSSocket.emit (events.js:211:7)
+    at addChunk (_stream_readable.js:263:12)
+    at readableAddChunk (_stream_readable.js:250:11)
+    at TLSSocket.Readable.push (_stream_readable.js:208:10)
+    at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+[Wed Nov 28 2018 18:51:45 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+    at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
+    at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
+    at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
+    at SMTPConnection.once (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:188:17)
+    at Object.onceWrapper (events.js:313:30)
+    at emitNone (events.js:106:13)
+    at SMTPConnection.emit (events.js:208:7)
+    at SMTPConnection._actionEHLO (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:1133:14)
+    at SMTPConnection._processResponse (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:764:20)
+    at SMTPConnection._onData (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:570:14)
+    at TLSSocket._socket.on.chunk (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:522:47)
+    at emitOne (events.js:116:13)
+    at TLSSocket.emit (events.js:211:7)
+    at addChunk (_stream_readable.js:263:12)
+    at readableAddChunk (_stream_readable.js:250:11)
+    at TLSSocket.Readable.push (_stream_readable.js:208:10)
+    at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+[Wed Nov 28 2018 18:51:46 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+    at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
+    at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
+    at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
+    at SMTPConnection.once (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:188:17)
+    at Object.onceWrapper (events.js:313:30)
+    at emitNone (events.js:106:13)
+    at SMTPConnection.emit (events.js:208:7)
+    at SMTPConnection._actionEHLO (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:1133:14)
+    at SMTPConnection._processResponse (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:764:20)
+    at SMTPConnection._onData (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:570:14)
+    at TLSSocket._socket.on.chunk (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:522:47)
+    at emitOne (events.js:116:13)
+    at TLSSocket.emit (events.js:211:7)
+    at addChunk (_stream_readable.js:263:12)
+    at readableAddChunk (_stream_readable.js:250:11)
+    at TLSSocket.Readable.push (_stream_readable.js:208:10)
+    at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+[Wed Nov 28 2018 18:51:46 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+    at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
+    at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
+    at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
+    at SMTPConnection.once (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:188:17)
+    at Object.onceWrapper (events.js:313:30)
+    at emitNone (events.js:106:13)
+    at SMTPConnection.emit (events.js:208:7)
+    at SMTPConnection._actionEHLO (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:1133:14)
+    at SMTPConnection._processResponse (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:764:20)
+    at SMTPConnection._onData (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:570:14)
+    at TLSSocket._socket.on.chunk (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:522:47)
+    at emitOne (events.js:116:13)
+    at TLSSocket.emit (events.js:211:7)
+    at addChunk (_stream_readable.js:263:12)
+    at readableAddChunk (_stream_readable.js:250:11)
+    at TLSSocket.Readable.push (_stream_readable.js:208:10)
+    at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+[Wed Nov 28 2018 18:51:46 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+    at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
+    at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
+    at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
+    at SMTPConnection.once (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:188:17)
+    at Object.onceWrapper (events.js:313:30)
+    at emitNone (events.js:106:13)
+    at SMTPConnection.emit (events.js:208:7)
+    at SMTPConnection._actionEHLO (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:1133:14)
+    at SMTPConnection._processResponse (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:764:20)
+    at SMTPConnection._onData (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:570:14)
+    at TLSSocket._socket.on.chunk (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:522:47)
+    at emitOne (events.js:116:13)
+    at TLSSocket.emit (events.js:211:7)
+    at addChunk (_stream_readable.js:263:12)
+    at readableAddChunk (_stream_readable.js:250:11)
+    at TLSSocket.Readable.push (_stream_readable.js:208:10)
+    at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+[Wed Nov 28 2018 18:51:46 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+    at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
+    at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
+    at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
+    at SMTPConnection.once (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:188:17)
+    at Object.onceWrapper (events.js:313:30)
+    at emitNone (events.js:106:13)
+    at SMTPConnection.emit (events.js:208:7)
+    at SMTPConnection._actionEHLO (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:1133:14)
+    at SMTPConnection._processResponse (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:764:20)
+    at SMTPConnection._onData (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:570:14)
+    at TLSSocket._socket.on.chunk (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:522:47)
+    at emitOne (events.js:116:13)
+    at TLSSocket.emit (events.js:211:7)
+    at addChunk (_stream_readable.js:263:12)
+    at readableAddChunk (_stream_readable.js:250:11)
+    at TLSSocket.Readable.push (_stream_readable.js:208:10)
+    at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+[Wed Nov 28 2018 18:51:46 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+    at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
+    at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
+    at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
+    at SMTPConnection.once (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:188:17)
+    at Object.onceWrapper (events.js:313:30)
+    at emitNone (events.js:106:13)
+    at SMTPConnection.emit (events.js:208:7)
+    at SMTPConnection._actionEHLO (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:1133:14)
+    at SMTPConnection._processResponse (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:764:20)
+    at SMTPConnection._onData (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:570:14)
+    at TLSSocket._socket.on.chunk (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:522:47)
+    at emitOne (events.js:116:13)
+    at TLSSocket.emit (events.js:211:7)
+    at addChunk (_stream_readable.js:263:12)
+    at readableAddChunk (_stream_readable.js:250:11)
+    at TLSSocket.Readable.push (_stream_readable.js:208:10)
+    at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+[Wed Nov 28 2018 18:51:46 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+    at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
+    at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
+    at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
+    at SMTPConnection.once (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:188:17)
+    at Object.onceWrapper (events.js:313:30)
+    at emitNone (events.js:106:13)
+    at SMTPConnection.emit (events.js:208:7)
+    at SMTPConnection._actionEHLO (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:1133:14)
+    at SMTPConnection._processResponse (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:764:20)
+    at SMTPConnection._onData (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:570:14)
+    at TLSSocket._socket.on.chunk (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:522:47)
+    at emitOne (events.js:116:13)
+    at TLSSocket.emit (events.js:211:7)
+    at addChunk (_stream_readable.js:263:12)
+    at readableAddChunk (_stream_readable.js:250:11)
+    at TLSSocket.Readable.push (_stream_readable.js:208:10)
+    at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+[Wed Nov 28 2018 18:51:46 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+    at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
+    at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
+    at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
+    at SMTPConnection.once (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:188:17)
+    at Object.onceWrapper (events.js:313:30)
+    at emitNone (events.js:106:13)
+    at SMTPConnection.emit (events.js:208:7)
+    at SMTPConnection._actionEHLO (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:1133:14)
+    at SMTPConnection._processResponse (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:764:20)
+    at SMTPConnection._onData (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:570:14)
+    at TLSSocket._socket.on.chunk (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:522:47)
+    at emitOne (events.js:116:13)
+    at TLSSocket.emit (events.js:211:7)
+    at addChunk (_stream_readable.js:263:12)
+    at readableAddChunk (_stream_readable.js:250:11)
+    at TLSSocket.Readable.push (_stream_readable.js:208:10)
+    at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+[Wed Nov 28 2018 18:51:46 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+    at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
+    at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
+    at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
+    at SMTPConnection.once (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:188:17)
+    at Object.onceWrapper (events.js:313:30)
+    at emitNone (events.js:106:13)
+    at SMTPConnection.emit (events.js:208:7)
+    at SMTPConnection._actionEHLO (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:1133:14)
+    at SMTPConnection._processResponse (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:764:20)
+    at SMTPConnection._onData (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:570:14)
+    at TLSSocket._socket.on.chunk (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:522:47)
+    at emitOne (events.js:116:13)
+    at TLSSocket.emit (events.js:211:7)
+    at addChunk (_stream_readable.js:263:12)
+    at readableAddChunk (_stream_readable.js:250:11)
+    at TLSSocket.Readable.push (_stream_readable.js:208:10)
+    at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+[Wed Nov 28 2018 18:51:46 GMT+0100 (WAT)] : 'This is just an error logger test'
+[Wed Nov 28 2018 18:51:46 GMT+0100 (WAT)] : 'This is just an error logger test'
+[Wed Nov 28 2018 18:51:46 GMT+0100 (WAT)] : 'This is just an error logger test'
+[Wed Nov 28 2018 18:52:37 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+    at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
+    at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
+    at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
+    at SMTPConnection.once (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:188:17)
+    at Object.onceWrapper (events.js:313:30)
+    at emitNone (events.js:106:13)
+    at SMTPConnection.emit (events.js:208:7)
+    at SMTPConnection._actionEHLO (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:1133:14)
+    at SMTPConnection._processResponse (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:764:20)
+    at SMTPConnection._onData (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:570:14)
+    at TLSSocket._socket.on.chunk (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:522:47)
+    at emitOne (events.js:116:13)
+    at TLSSocket.emit (events.js:211:7)
+    at addChunk (_stream_readable.js:263:12)
+    at readableAddChunk (_stream_readable.js:250:11)
+    at TLSSocket.Readable.push (_stream_readable.js:208:10)
+    at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+[Wed Nov 28 2018 18:52:37 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+    at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
+    at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
+    at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
+    at SMTPConnection.once (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:188:17)
+    at Object.onceWrapper (events.js:313:30)
+    at emitNone (events.js:106:13)
+    at SMTPConnection.emit (events.js:208:7)
+    at SMTPConnection._actionEHLO (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:1133:14)
+    at SMTPConnection._processResponse (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:764:20)
+    at SMTPConnection._onData (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:570:14)
+    at TLSSocket._socket.on.chunk (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:522:47)
+    at emitOne (events.js:116:13)
+    at TLSSocket.emit (events.js:211:7)
+    at addChunk (_stream_readable.js:263:12)
+    at readableAddChunk (_stream_readable.js:250:11)
+    at TLSSocket.Readable.push (_stream_readable.js:208:10)
+    at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+[Wed Nov 28 2018 18:52:37 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+    at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
+    at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
+    at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
+    at SMTPConnection.once (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:188:17)
+    at Object.onceWrapper (events.js:313:30)
+    at emitNone (events.js:106:13)
+    at SMTPConnection.emit (events.js:208:7)
+    at SMTPConnection._actionEHLO (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:1133:14)
+    at SMTPConnection._processResponse (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:764:20)
+    at SMTPConnection._onData (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:570:14)
+    at TLSSocket._socket.on.chunk (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:522:47)
+    at emitOne (events.js:116:13)
+    at TLSSocket.emit (events.js:211:7)
+    at addChunk (_stream_readable.js:263:12)
+    at readableAddChunk (_stream_readable.js:250:11)
+    at TLSSocket.Readable.push (_stream_readable.js:208:10)
+    at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+[Wed Nov 28 2018 18:52:37 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+    at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
+    at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
+    at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
+    at SMTPConnection.once (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:188:17)
+    at Object.onceWrapper (events.js:313:30)
+    at emitNone (events.js:106:13)
+    at SMTPConnection.emit (events.js:208:7)
+    at SMTPConnection._actionEHLO (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:1133:14)
+    at SMTPConnection._processResponse (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:764:20)
+    at SMTPConnection._onData (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:570:14)
+    at TLSSocket._socket.on.chunk (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:522:47)
+    at emitOne (events.js:116:13)
+    at TLSSocket.emit (events.js:211:7)
+    at addChunk (_stream_readable.js:263:12)
+    at readableAddChunk (_stream_readable.js:250:11)
+    at TLSSocket.Readable.push (_stream_readable.js:208:10)
+    at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+[Wed Nov 28 2018 18:52:38 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+    at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
+    at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
+    at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
+    at SMTPConnection.once (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:188:17)
+    at Object.onceWrapper (events.js:313:30)
+    at emitNone (events.js:106:13)
+    at SMTPConnection.emit (events.js:208:7)
+    at SMTPConnection._actionEHLO (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:1133:14)
+    at SMTPConnection._processResponse (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:764:20)
+    at SMTPConnection._onData (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:570:14)
+    at TLSSocket._socket.on.chunk (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:522:47)
+    at emitOne (events.js:116:13)
+    at TLSSocket.emit (events.js:211:7)
+    at addChunk (_stream_readable.js:263:12)
+    at readableAddChunk (_stream_readable.js:250:11)
+    at TLSSocket.Readable.push (_stream_readable.js:208:10)
+    at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+[Wed Nov 28 2018 18:52:38 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+    at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
+    at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
+    at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
+    at SMTPConnection.once (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:188:17)
+    at Object.onceWrapper (events.js:313:30)
+    at emitNone (events.js:106:13)
+    at SMTPConnection.emit (events.js:208:7)
+    at SMTPConnection._actionEHLO (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:1133:14)
+    at SMTPConnection._processResponse (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:764:20)
+    at SMTPConnection._onData (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:570:14)
+    at TLSSocket._socket.on.chunk (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:522:47)
+    at emitOne (events.js:116:13)
+    at TLSSocket.emit (events.js:211:7)
+    at addChunk (_stream_readable.js:263:12)
+    at readableAddChunk (_stream_readable.js:250:11)
+    at TLSSocket.Readable.push (_stream_readable.js:208:10)
+    at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+[Wed Nov 28 2018 18:52:38 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+    at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
+    at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
+    at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
+    at SMTPConnection.once (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:188:17)
+    at Object.onceWrapper (events.js:313:30)
+    at emitNone (events.js:106:13)
+    at SMTPConnection.emit (events.js:208:7)
+    at SMTPConnection._actionEHLO (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:1133:14)
+    at SMTPConnection._processResponse (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:764:20)
+    at SMTPConnection._onData (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:570:14)
+    at TLSSocket._socket.on.chunk (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:522:47)
+    at emitOne (events.js:116:13)
+    at TLSSocket.emit (events.js:211:7)
+    at addChunk (_stream_readable.js:263:12)
+    at readableAddChunk (_stream_readable.js:250:11)
+    at TLSSocket.Readable.push (_stream_readable.js:208:10)
+    at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+[Wed Nov 28 2018 18:52:38 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+    at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
+    at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
+    at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
+    at SMTPConnection.once (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:188:17)
+    at Object.onceWrapper (events.js:313:30)
+    at emitNone (events.js:106:13)
+    at SMTPConnection.emit (events.js:208:7)
+    at SMTPConnection._actionEHLO (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:1133:14)
+    at SMTPConnection._processResponse (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:764:20)
+    at SMTPConnection._onData (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:570:14)
+    at TLSSocket._socket.on.chunk (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:522:47)
+    at emitOne (events.js:116:13)
+    at TLSSocket.emit (events.js:211:7)
+    at addChunk (_stream_readable.js:263:12)
+    at readableAddChunk (_stream_readable.js:250:11)
+    at TLSSocket.Readable.push (_stream_readable.js:208:10)
+    at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+[Wed Nov 28 2018 18:52:38 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+    at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
+    at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
+    at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
+    at SMTPConnection.once (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:188:17)
+    at Object.onceWrapper (events.js:313:30)
+    at emitNone (events.js:106:13)
+    at SMTPConnection.emit (events.js:208:7)
+    at SMTPConnection._actionEHLO (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:1133:14)
+    at SMTPConnection._processResponse (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:764:20)
+    at SMTPConnection._onData (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:570:14)
+    at TLSSocket._socket.on.chunk (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:522:47)
+    at emitOne (events.js:116:13)
+    at TLSSocket.emit (events.js:211:7)
+    at addChunk (_stream_readable.js:263:12)
+    at readableAddChunk (_stream_readable.js:250:11)
+    at TLSSocket.Readable.push (_stream_readable.js:208:10)
+    at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+[Wed Nov 28 2018 18:52:38 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+    at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
+    at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
+    at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
+    at SMTPConnection.once (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:188:17)
+    at Object.onceWrapper (events.js:313:30)
+    at emitNone (events.js:106:13)
+    at SMTPConnection.emit (events.js:208:7)
+    at SMTPConnection._actionEHLO (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:1133:14)
+    at SMTPConnection._processResponse (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:764:20)
+    at SMTPConnection._onData (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:570:14)
+    at TLSSocket._socket.on.chunk (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:522:47)
+    at emitOne (events.js:116:13)
+    at TLSSocket.emit (events.js:211:7)
+    at addChunk (_stream_readable.js:263:12)
+    at readableAddChunk (_stream_readable.js:250:11)
+    at TLSSocket.Readable.push (_stream_readable.js:208:10)
+    at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+[Wed Nov 28 2018 18:52:39 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+    at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
+    at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
+    at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
+    at SMTPConnection.once (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:188:17)
+    at Object.onceWrapper (events.js:313:30)
+    at emitNone (events.js:106:13)
+    at SMTPConnection.emit (events.js:208:7)
+    at SMTPConnection._actionEHLO (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:1133:14)
+    at SMTPConnection._processResponse (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:764:20)
+    at SMTPConnection._onData (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:570:14)
+    at TLSSocket._socket.on.chunk (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:522:47)
+    at emitOne (events.js:116:13)
+    at TLSSocket.emit (events.js:211:7)
+    at addChunk (_stream_readable.js:263:12)
+    at readableAddChunk (_stream_readable.js:250:11)
+    at TLSSocket.Readable.push (_stream_readable.js:208:10)
+    at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+[Wed Nov 28 2018 18:52:39 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+    at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
+    at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
+    at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
+    at SMTPConnection.once (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:188:17)
+    at Object.onceWrapper (events.js:313:30)
+    at emitNone (events.js:106:13)
+    at SMTPConnection.emit (events.js:208:7)
+    at SMTPConnection._actionEHLO (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:1133:14)
+    at SMTPConnection._processResponse (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:764:20)
+    at SMTPConnection._onData (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:570:14)
+    at TLSSocket._socket.on.chunk (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:522:47)
+    at emitOne (events.js:116:13)
+    at TLSSocket.emit (events.js:211:7)
+    at addChunk (_stream_readable.js:263:12)
+    at readableAddChunk (_stream_readable.js:250:11)
+    at TLSSocket.Readable.push (_stream_readable.js:208:10)
+    at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+[Wed Nov 28 2018 18:52:39 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+    at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
+    at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
+    at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
+    at SMTPConnection.once (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:188:17)
+    at Object.onceWrapper (events.js:313:30)
+    at emitNone (events.js:106:13)
+    at SMTPConnection.emit (events.js:208:7)
+    at SMTPConnection._actionEHLO (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:1133:14)
+    at SMTPConnection._processResponse (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:764:20)
+    at SMTPConnection._onData (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:570:14)
+    at TLSSocket._socket.on.chunk (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:522:47)
+    at emitOne (events.js:116:13)
+    at TLSSocket.emit (events.js:211:7)
+    at addChunk (_stream_readable.js:263:12)
+    at readableAddChunk (_stream_readable.js:250:11)
+    at TLSSocket.Readable.push (_stream_readable.js:208:10)
+    at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+[Wed Nov 28 2018 18:52:40 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+    at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
+    at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
+    at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
+    at SMTPConnection.once (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:188:17)
+    at Object.onceWrapper (events.js:313:30)
+    at emitNone (events.js:106:13)
+    at SMTPConnection.emit (events.js:208:7)
+    at SMTPConnection._actionEHLO (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:1133:14)
+    at SMTPConnection._processResponse (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:764:20)
+    at SMTPConnection._onData (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:570:14)
+    at TLSSocket._socket.on.chunk (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:522:47)
+    at emitOne (events.js:116:13)
+    at TLSSocket.emit (events.js:211:7)
+    at addChunk (_stream_readable.js:263:12)
+    at readableAddChunk (_stream_readable.js:250:11)
+    at TLSSocket.Readable.push (_stream_readable.js:208:10)
+    at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+[Wed Nov 28 2018 18:52:40 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+    at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
+    at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
+    at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
+    at SMTPConnection.once (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:188:17)
+    at Object.onceWrapper (events.js:313:30)
+    at emitNone (events.js:106:13)
+    at SMTPConnection.emit (events.js:208:7)
+    at SMTPConnection._actionEHLO (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:1133:14)
+    at SMTPConnection._processResponse (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:764:20)
+    at SMTPConnection._onData (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:570:14)
+    at TLSSocket._socket.on.chunk (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:522:47)
+    at emitOne (events.js:116:13)
+    at TLSSocket.emit (events.js:211:7)
+    at addChunk (_stream_readable.js:263:12)
+    at readableAddChunk (_stream_readable.js:250:11)
+    at TLSSocket.Readable.push (_stream_readable.js:208:10)
+    at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+[Wed Nov 28 2018 18:52:40 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+    at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
+    at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
+    at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
+    at SMTPConnection.once (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:188:17)
+    at Object.onceWrapper (events.js:313:30)
+    at emitNone (events.js:106:13)
+    at SMTPConnection.emit (events.js:208:7)
+    at SMTPConnection._actionEHLO (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:1133:14)
+    at SMTPConnection._processResponse (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:764:20)
+    at SMTPConnection._onData (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:570:14)
+    at TLSSocket._socket.on.chunk (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:522:47)
+    at emitOne (events.js:116:13)
+    at TLSSocket.emit (events.js:211:7)
+    at addChunk (_stream_readable.js:263:12)
+    at readableAddChunk (_stream_readable.js:250:11)
+    at TLSSocket.Readable.push (_stream_readable.js:208:10)
+    at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+[Wed Nov 28 2018 18:52:40 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+    at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
+    at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
+    at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
+    at SMTPConnection.once (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:188:17)
+    at Object.onceWrapper (events.js:313:30)
+    at emitNone (events.js:106:13)
+    at SMTPConnection.emit (events.js:208:7)
+    at SMTPConnection._actionEHLO (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:1133:14)
+    at SMTPConnection._processResponse (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:764:20)
+    at SMTPConnection._onData (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:570:14)
+    at TLSSocket._socket.on.chunk (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:522:47)
+    at emitOne (events.js:116:13)
+    at TLSSocket.emit (events.js:211:7)
+    at addChunk (_stream_readable.js:263:12)
+    at readableAddChunk (_stream_readable.js:250:11)
+    at TLSSocket.Readable.push (_stream_readable.js:208:10)
+    at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+[Wed Nov 28 2018 18:52:40 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+    at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
+    at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
+    at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
+    at SMTPConnection.once (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:188:17)
+    at Object.onceWrapper (events.js:313:30)
+    at emitNone (events.js:106:13)
+    at SMTPConnection.emit (events.js:208:7)
+    at SMTPConnection._actionEHLO (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:1133:14)
+    at SMTPConnection._processResponse (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:764:20)
+    at SMTPConnection._onData (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:570:14)
+    at TLSSocket._socket.on.chunk (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:522:47)
+    at emitOne (events.js:116:13)
+    at TLSSocket.emit (events.js:211:7)
+    at addChunk (_stream_readable.js:263:12)
+    at readableAddChunk (_stream_readable.js:250:11)
+    at TLSSocket.Readable.push (_stream_readable.js:208:10)
+    at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+[Wed Nov 28 2018 18:52:40 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+    at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
+    at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
+    at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
+    at SMTPConnection.once (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:188:17)
+    at Object.onceWrapper (events.js:313:30)
+    at emitNone (events.js:106:13)
+    at SMTPConnection.emit (events.js:208:7)
+    at SMTPConnection._actionEHLO (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:1133:14)
+    at SMTPConnection._processResponse (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:764:20)
+    at SMTPConnection._onData (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:570:14)
+    at TLSSocket._socket.on.chunk (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:522:47)
+    at emitOne (events.js:116:13)
+    at TLSSocket.emit (events.js:211:7)
+    at addChunk (_stream_readable.js:263:12)
+    at readableAddChunk (_stream_readable.js:250:11)
+    at TLSSocket.Readable.push (_stream_readable.js:208:10)
+    at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+[Wed Nov 28 2018 18:52:41 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+    at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
+    at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
+    at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
+    at SMTPConnection.once (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:188:17)
+    at Object.onceWrapper (events.js:313:30)
+    at emitNone (events.js:106:13)
+    at SMTPConnection.emit (events.js:208:7)
+    at SMTPConnection._actionEHLO (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:1133:14)
+    at SMTPConnection._processResponse (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:764:20)
+    at SMTPConnection._onData (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:570:14)
+    at TLSSocket._socket.on.chunk (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:522:47)
+    at emitOne (events.js:116:13)
+    at TLSSocket.emit (events.js:211:7)
+    at addChunk (_stream_readable.js:263:12)
+    at readableAddChunk (_stream_readable.js:250:11)
+    at TLSSocket.Readable.push (_stream_readable.js:208:10)
+    at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+[Wed Nov 28 2018 18:52:41 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+    at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
+    at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
+    at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
+    at SMTPConnection.once (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:188:17)
+    at Object.onceWrapper (events.js:313:30)
+    at emitNone (events.js:106:13)
+    at SMTPConnection.emit (events.js:208:7)
+    at SMTPConnection._actionEHLO (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:1133:14)
+    at SMTPConnection._processResponse (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:764:20)
+    at SMTPConnection._onData (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:570:14)
+    at TLSSocket._socket.on.chunk (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:522:47)
+    at emitOne (events.js:116:13)
+    at TLSSocket.emit (events.js:211:7)
+    at addChunk (_stream_readable.js:263:12)
+    at readableAddChunk (_stream_readable.js:250:11)
+    at TLSSocket.Readable.push (_stream_readable.js:208:10)
+    at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+[Wed Nov 28 2018 18:52:41 GMT+0100 (WAT)] : 'This is just an error logger test'
+[Wed Nov 28 2018 18:52:41 GMT+0100 (WAT)] : 'This is just an error logger test'
+[Wed Nov 28 2018 18:52:41 GMT+0100 (WAT)] : 'This is just an error logger test'
+>>>>>>> bug(reactivate user): Allow user reactivate account
+[Thu Nov 29 2018 16:41:49 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+    at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
+    at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
+    at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
+    at SMTPConnection.once (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:188:17)
+    at Object.onceWrapper (events.js:313:30)
+    at emitNone (events.js:106:13)
+    at SMTPConnection.emit (events.js:208:7)
+    at SMTPConnection._actionEHLO (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:1133:14)
+    at SMTPConnection._processResponse (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:764:20)
+    at SMTPConnection._onData (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:570:14)
+    at TLSSocket._socket.on.chunk (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:522:47)
+    at emitOne (events.js:116:13)
+    at TLSSocket.emit (events.js:211:7)
+    at addChunk (_stream_readable.js:263:12)
+    at readableAddChunk (_stream_readable.js:250:11)
+    at TLSSocket.Readable.push (_stream_readable.js:208:10)
+    at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+[Thu Nov 29 2018 16:41:49 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+    at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
+    at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
+    at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
+    at SMTPConnection.once (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:188:17)
+    at Object.onceWrapper (events.js:313:30)
+    at emitNone (events.js:106:13)
+    at SMTPConnection.emit (events.js:208:7)
+    at SMTPConnection._actionEHLO (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:1133:14)
+    at SMTPConnection._processResponse (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:764:20)
+    at SMTPConnection._onData (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:570:14)
+    at TLSSocket._socket.on.chunk (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:522:47)
+    at emitOne (events.js:116:13)
+    at TLSSocket.emit (events.js:211:7)
+    at addChunk (_stream_readable.js:263:12)
+    at readableAddChunk (_stream_readable.js:250:11)
+    at TLSSocket.Readable.push (_stream_readable.js:208:10)
+    at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+[Thu Nov 29 2018 16:41:49 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+    at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
+    at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
+    at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
+    at SMTPConnection.once (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:188:17)
+    at Object.onceWrapper (events.js:313:30)
+    at emitNone (events.js:106:13)
+    at SMTPConnection.emit (events.js:208:7)
+    at SMTPConnection._actionEHLO (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:1133:14)
+    at SMTPConnection._processResponse (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:764:20)
+    at SMTPConnection._onData (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:570:14)
+    at TLSSocket._socket.on.chunk (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:522:47)
+    at emitOne (events.js:116:13)
+    at TLSSocket.emit (events.js:211:7)
+    at addChunk (_stream_readable.js:263:12)
+    at readableAddChunk (_stream_readable.js:250:11)
+    at TLSSocket.Readable.push (_stream_readable.js:208:10)
+    at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+[Thu Nov 29 2018 16:41:49 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+    at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
+    at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
+    at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
+    at SMTPConnection.once (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:188:17)
+    at Object.onceWrapper (events.js:313:30)
+    at emitNone (events.js:106:13)
+    at SMTPConnection.emit (events.js:208:7)
+    at SMTPConnection._actionEHLO (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:1133:14)
+    at SMTPConnection._processResponse (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:764:20)
+    at SMTPConnection._onData (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:570:14)
+    at TLSSocket._socket.on.chunk (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:522:47)
+    at emitOne (events.js:116:13)
+    at TLSSocket.emit (events.js:211:7)
+    at addChunk (_stream_readable.js:263:12)
+    at readableAddChunk (_stream_readable.js:250:11)
+    at TLSSocket.Readable.push (_stream_readable.js:208:10)
+    at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+[Thu Nov 29 2018 16:41:50 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+    at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
+    at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
+    at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
+    at SMTPConnection.once (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:188:17)
+    at Object.onceWrapper (events.js:313:30)
+    at emitNone (events.js:106:13)
+    at SMTPConnection.emit (events.js:208:7)
+    at SMTPConnection._actionEHLO (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:1133:14)
+    at SMTPConnection._processResponse (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:764:20)
+    at SMTPConnection._onData (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:570:14)
+    at TLSSocket._socket.on.chunk (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:522:47)
+    at emitOne (events.js:116:13)
+    at TLSSocket.emit (events.js:211:7)
+    at addChunk (_stream_readable.js:263:12)
+    at readableAddChunk (_stream_readable.js:250:11)
+    at TLSSocket.Readable.push (_stream_readable.js:208:10)
+    at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+[Thu Nov 29 2018 16:41:50 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+    at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
+    at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
+    at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
+    at SMTPConnection.once (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:188:17)
+    at Object.onceWrapper (events.js:313:30)
+    at emitNone (events.js:106:13)
+    at SMTPConnection.emit (events.js:208:7)
+    at SMTPConnection._actionEHLO (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:1133:14)
+    at SMTPConnection._processResponse (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:764:20)
+    at SMTPConnection._onData (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:570:14)
+    at TLSSocket._socket.on.chunk (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:522:47)
+    at emitOne (events.js:116:13)
+    at TLSSocket.emit (events.js:211:7)
+    at addChunk (_stream_readable.js:263:12)
+    at readableAddChunk (_stream_readable.js:250:11)
+    at TLSSocket.Readable.push (_stream_readable.js:208:10)
+    at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+[Thu Nov 29 2018 16:41:50 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+    at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
+    at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
+    at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
+    at SMTPConnection.once (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:188:17)
+    at Object.onceWrapper (events.js:313:30)
+    at emitNone (events.js:106:13)
+    at SMTPConnection.emit (events.js:208:7)
+    at SMTPConnection._actionEHLO (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:1133:14)
+    at SMTPConnection._processResponse (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:764:20)
+    at SMTPConnection._onData (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:570:14)
+    at TLSSocket._socket.on.chunk (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:522:47)
+    at emitOne (events.js:116:13)
+    at TLSSocket.emit (events.js:211:7)
+    at addChunk (_stream_readable.js:263:12)
+    at readableAddChunk (_stream_readable.js:250:11)
+    at TLSSocket.Readable.push (_stream_readable.js:208:10)
+    at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+[Thu Nov 29 2018 16:41:50 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+    at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
+    at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
+    at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
+    at SMTPConnection.once (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:188:17)
+    at Object.onceWrapper (events.js:313:30)
+    at emitNone (events.js:106:13)
+    at SMTPConnection.emit (events.js:208:7)
+    at SMTPConnection._actionEHLO (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:1133:14)
+    at SMTPConnection._processResponse (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:764:20)
+    at SMTPConnection._onData (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:570:14)
+    at TLSSocket._socket.on.chunk (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:522:47)
+    at emitOne (events.js:116:13)
+    at TLSSocket.emit (events.js:211:7)
+    at addChunk (_stream_readable.js:263:12)
+    at readableAddChunk (_stream_readable.js:250:11)
+    at TLSSocket.Readable.push (_stream_readable.js:208:10)
+    at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+[Thu Nov 29 2018 16:41:50 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+    at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
+    at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
+    at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
+    at SMTPConnection.once (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:188:17)
+    at Object.onceWrapper (events.js:313:30)
+    at emitNone (events.js:106:13)
+    at SMTPConnection.emit (events.js:208:7)
+    at SMTPConnection._actionEHLO (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:1133:14)
+    at SMTPConnection._processResponse (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:764:20)
+    at SMTPConnection._onData (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:570:14)
+    at TLSSocket._socket.on.chunk (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:522:47)
+    at emitOne (events.js:116:13)
+    at TLSSocket.emit (events.js:211:7)
+    at addChunk (_stream_readable.js:263:12)
+    at readableAddChunk (_stream_readable.js:250:11)
+    at TLSSocket.Readable.push (_stream_readable.js:208:10)
+    at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+[Thu Nov 29 2018 16:41:50 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+    at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
+    at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
+    at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
+    at SMTPConnection.once (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:188:17)
+    at Object.onceWrapper (events.js:313:30)
+    at emitNone (events.js:106:13)
+    at SMTPConnection.emit (events.js:208:7)
+    at SMTPConnection._actionEHLO (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:1133:14)
+    at SMTPConnection._processResponse (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:764:20)
+    at SMTPConnection._onData (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:570:14)
+    at TLSSocket._socket.on.chunk (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:522:47)
+    at emitOne (events.js:116:13)
+    at TLSSocket.emit (events.js:211:7)
+    at addChunk (_stream_readable.js:263:12)
+    at readableAddChunk (_stream_readable.js:250:11)
+    at TLSSocket.Readable.push (_stream_readable.js:208:10)
+    at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+[Thu Nov 29 2018 16:41:50 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+    at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
+    at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
+    at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
+    at SMTPConnection.once (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:188:17)
+    at Object.onceWrapper (events.js:313:30)
+    at emitNone (events.js:106:13)
+    at SMTPConnection.emit (events.js:208:7)
+    at SMTPConnection._actionEHLO (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:1133:14)
+    at SMTPConnection._processResponse (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:764:20)
+    at SMTPConnection._onData (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:570:14)
+    at TLSSocket._socket.on.chunk (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:522:47)
+    at emitOne (events.js:116:13)
+    at TLSSocket.emit (events.js:211:7)
+    at addChunk (_stream_readable.js:263:12)
+    at readableAddChunk (_stream_readable.js:250:11)
+    at TLSSocket.Readable.push (_stream_readable.js:208:10)
+    at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+[Thu Nov 29 2018 16:41:51 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+    at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
+    at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
+    at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
+    at SMTPConnection.once (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:188:17)
+    at Object.onceWrapper (events.js:313:30)
+    at emitNone (events.js:106:13)
+    at SMTPConnection.emit (events.js:208:7)
+    at SMTPConnection._actionEHLO (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:1133:14)
+    at SMTPConnection._processResponse (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:764:20)
+    at SMTPConnection._onData (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:570:14)
+    at TLSSocket._socket.on.chunk (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:522:47)
+    at emitOne (events.js:116:13)
+    at TLSSocket.emit (events.js:211:7)
+    at addChunk (_stream_readable.js:263:12)
+    at readableAddChunk (_stream_readable.js:250:11)
+    at TLSSocket.Readable.push (_stream_readable.js:208:10)
+    at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+[Thu Nov 29 2018 16:41:51 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+    at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
+    at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
+    at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
+    at SMTPConnection.once (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:188:17)
+    at Object.onceWrapper (events.js:313:30)
+    at emitNone (events.js:106:13)
+    at SMTPConnection.emit (events.js:208:7)
+    at SMTPConnection._actionEHLO (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:1133:14)
+    at SMTPConnection._processResponse (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:764:20)
+    at SMTPConnection._onData (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:570:14)
+    at TLSSocket._socket.on.chunk (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:522:47)
+    at emitOne (events.js:116:13)
+    at TLSSocket.emit (events.js:211:7)
+    at addChunk (_stream_readable.js:263:12)
+    at readableAddChunk (_stream_readable.js:250:11)
+    at TLSSocket.Readable.push (_stream_readable.js:208:10)
+    at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+[Thu Nov 29 2018 16:41:52 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+    at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
+    at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
+    at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
+    at SMTPConnection.once (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:188:17)
+    at Object.onceWrapper (events.js:313:30)
+    at emitNone (events.js:106:13)
+    at SMTPConnection.emit (events.js:208:7)
+    at SMTPConnection._actionEHLO (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:1133:14)
+    at SMTPConnection._processResponse (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:764:20)
+    at SMTPConnection._onData (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:570:14)
+    at TLSSocket._socket.on.chunk (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:522:47)
+    at emitOne (events.js:116:13)
+    at TLSSocket.emit (events.js:211:7)
+    at addChunk (_stream_readable.js:263:12)
+    at readableAddChunk (_stream_readable.js:250:11)
+    at TLSSocket.Readable.push (_stream_readable.js:208:10)
+    at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+[Thu Nov 29 2018 16:41:52 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+    at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
+    at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
+    at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
+    at SMTPConnection.once (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:188:17)
+    at Object.onceWrapper (events.js:313:30)
+    at emitNone (events.js:106:13)
+    at SMTPConnection.emit (events.js:208:7)
+    at SMTPConnection._actionEHLO (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:1133:14)
+    at SMTPConnection._processResponse (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:764:20)
+    at SMTPConnection._onData (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:570:14)
+    at TLSSocket._socket.on.chunk (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:522:47)
+    at emitOne (events.js:116:13)
+    at TLSSocket.emit (events.js:211:7)
+    at addChunk (_stream_readable.js:263:12)
+    at readableAddChunk (_stream_readable.js:250:11)
+    at TLSSocket.Readable.push (_stream_readable.js:208:10)
+    at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+[Thu Nov 29 2018 16:41:52 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+    at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
+    at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
+    at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
+    at SMTPConnection.once (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:188:17)
+    at Object.onceWrapper (events.js:313:30)
+    at emitNone (events.js:106:13)
+    at SMTPConnection.emit (events.js:208:7)
+    at SMTPConnection._actionEHLO (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:1133:14)
+    at SMTPConnection._processResponse (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:764:20)
+    at SMTPConnection._onData (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:570:14)
+    at TLSSocket._socket.on.chunk (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:522:47)
+    at emitOne (events.js:116:13)
+    at TLSSocket.emit (events.js:211:7)
+    at addChunk (_stream_readable.js:263:12)
+    at readableAddChunk (_stream_readable.js:250:11)
+    at TLSSocket.Readable.push (_stream_readable.js:208:10)
+    at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+[Thu Nov 29 2018 16:41:52 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+    at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
+    at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
+    at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
+    at SMTPConnection.once (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:188:17)
+    at Object.onceWrapper (events.js:313:30)
+    at emitNone (events.js:106:13)
+    at SMTPConnection.emit (events.js:208:7)
+    at SMTPConnection._actionEHLO (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:1133:14)
+    at SMTPConnection._processResponse (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:764:20)
+    at SMTPConnection._onData (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:570:14)
+    at TLSSocket._socket.on.chunk (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:522:47)
+    at emitOne (events.js:116:13)
+    at TLSSocket.emit (events.js:211:7)
+    at addChunk (_stream_readable.js:263:12)
+    at readableAddChunk (_stream_readable.js:250:11)
+    at TLSSocket.Readable.push (_stream_readable.js:208:10)
+    at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+[Thu Nov 29 2018 16:41:52 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+    at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
+    at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
+    at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
+    at SMTPConnection.once (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:188:17)
+    at Object.onceWrapper (events.js:313:30)
+    at emitNone (events.js:106:13)
+    at SMTPConnection.emit (events.js:208:7)
+    at SMTPConnection._actionEHLO (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:1133:14)
+    at SMTPConnection._processResponse (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:764:20)
+    at SMTPConnection._onData (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:570:14)
+    at TLSSocket._socket.on.chunk (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:522:47)
+    at emitOne (events.js:116:13)
+    at TLSSocket.emit (events.js:211:7)
+    at addChunk (_stream_readable.js:263:12)
+    at readableAddChunk (_stream_readable.js:250:11)
+    at TLSSocket.Readable.push (_stream_readable.js:208:10)
+    at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+[Thu Nov 29 2018 16:41:52 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+    at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
+    at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
+    at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
+    at SMTPConnection.once (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:188:17)
+    at Object.onceWrapper (events.js:313:30)
+    at emitNone (events.js:106:13)
+    at SMTPConnection.emit (events.js:208:7)
+    at SMTPConnection._actionEHLO (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:1133:14)
+    at SMTPConnection._processResponse (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:764:20)
+    at SMTPConnection._onData (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:570:14)
+    at TLSSocket._socket.on.chunk (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:522:47)
+    at emitOne (events.js:116:13)
+    at TLSSocket.emit (events.js:211:7)
+    at addChunk (_stream_readable.js:263:12)
+    at readableAddChunk (_stream_readable.js:250:11)
+    at TLSSocket.Readable.push (_stream_readable.js:208:10)
+    at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+[Thu Nov 29 2018 16:41:53 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+    at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
+    at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
+    at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
+    at SMTPConnection.once (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:188:17)
+    at Object.onceWrapper (events.js:313:30)
+    at emitNone (events.js:106:13)
+    at SMTPConnection.emit (events.js:208:7)
+    at SMTPConnection._actionEHLO (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:1133:14)
+    at SMTPConnection._processResponse (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:764:20)
+    at SMTPConnection._onData (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:570:14)
+    at TLSSocket._socket.on.chunk (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:522:47)
+    at emitOne (events.js:116:13)
+    at TLSSocket.emit (events.js:211:7)
+    at addChunk (_stream_readable.js:263:12)
+    at readableAddChunk (_stream_readable.js:250:11)
+    at TLSSocket.Readable.push (_stream_readable.js:208:10)
+    at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+[Thu Nov 29 2018 16:41:53 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+    at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
+    at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
+    at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
+    at SMTPConnection.once (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:188:17)
+    at Object.onceWrapper (events.js:313:30)
+    at emitNone (events.js:106:13)
+    at SMTPConnection.emit (events.js:208:7)
+    at SMTPConnection._actionEHLO (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:1133:14)
+    at SMTPConnection._processResponse (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:764:20)
+    at SMTPConnection._onData (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:570:14)
+    at TLSSocket._socket.on.chunk (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:522:47)
+    at emitOne (events.js:116:13)
+    at TLSSocket.emit (events.js:211:7)
+    at addChunk (_stream_readable.js:263:12)
+    at readableAddChunk (_stream_readable.js:250:11)
+    at TLSSocket.Readable.push (_stream_readable.js:208:10)
+    at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+[Thu Nov 29 2018 16:41:53 GMT+0100 (WAT)] : 'This is just an error logger test'
+[Thu Nov 29 2018 16:41:53 GMT+0100 (WAT)] : 'This is just an error logger test'
+[Thu Nov 29 2018 16:41:53 GMT+0100 (WAT)] : 'This is just an error logger test'
+[Thu Nov 29 2018 16:41:53 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+    at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
+    at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
+    at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
+    at SMTPConnection.once (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:188:17)
+    at Object.onceWrapper (events.js:313:30)
+    at emitNone (events.js:106:13)
+    at SMTPConnection.emit (events.js:208:7)
+    at SMTPConnection._actionEHLO (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:1133:14)
+    at SMTPConnection._processResponse (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:764:20)
+    at SMTPConnection._onData (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:570:14)
+    at TLSSocket._socket.on.chunk (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:522:47)
+    at emitOne (events.js:116:13)
+    at TLSSocket.emit (events.js:211:7)
+    at addChunk (_stream_readable.js:263:12)
+    at readableAddChunk (_stream_readable.js:250:11)
+    at TLSSocket.Readable.push (_stream_readable.js:208:10)
+    at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+[Thu Nov 29 2018 16:41:53 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+    at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
+    at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
+    at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
+    at SMTPConnection.once (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:188:17)
+    at Object.onceWrapper (events.js:313:30)
+    at emitNone (events.js:106:13)
+    at SMTPConnection.emit (events.js:208:7)
+    at SMTPConnection._actionEHLO (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:1133:14)
+    at SMTPConnection._processResponse (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:764:20)
+    at SMTPConnection._onData (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:570:14)
+    at TLSSocket._socket.on.chunk (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:522:47)
+    at emitOne (events.js:116:13)
+    at TLSSocket.emit (events.js:211:7)
+    at addChunk (_stream_readable.js:263:12)
+    at readableAddChunk (_stream_readable.js:250:11)
+    at TLSSocket.Readable.push (_stream_readable.js:208:10)
+    at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+[Thu Nov 29 2018 16:41:53 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+    at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
+    at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
+    at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
+    at SMTPConnection.once (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:188:17)
+    at Object.onceWrapper (events.js:313:30)
+    at emitNone (events.js:106:13)
+    at SMTPConnection.emit (events.js:208:7)
+    at SMTPConnection._actionEHLO (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:1133:14)
+    at SMTPConnection._processResponse (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:764:20)
+    at SMTPConnection._onData (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:570:14)
+    at TLSSocket._socket.on.chunk (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:522:47)
+    at emitOne (events.js:116:13)
+    at TLSSocket.emit (events.js:211:7)
+    at addChunk (_stream_readable.js:263:12)
+    at readableAddChunk (_stream_readable.js:250:11)
+    at TLSSocket.Readable.push (_stream_readable.js:208:10)
+    at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+[Thu Nov 29 2018 16:41:53 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+    at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
+    at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
+    at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
+    at SMTPConnection.once (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:188:17)
+    at Object.onceWrapper (events.js:313:30)
+    at emitNone (events.js:106:13)
+    at SMTPConnection.emit (events.js:208:7)
+    at SMTPConnection._actionEHLO (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:1133:14)
+    at SMTPConnection._processResponse (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:764:20)
+    at SMTPConnection._onData (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:570:14)
+    at TLSSocket._socket.on.chunk (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:522:47)
+    at emitOne (events.js:116:13)
+    at TLSSocket.emit (events.js:211:7)
+    at addChunk (_stream_readable.js:263:12)
+    at readableAddChunk (_stream_readable.js:250:11)
+    at TLSSocket.Readable.push (_stream_readable.js:208:10)
+    at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+[Thu Nov 29 2018 16:41:53 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
+    at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
+    at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
+    at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)
+    at SMTPConnection.once (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:188:17)
+    at Object.onceWrapper (events.js:313:30)
+    at emitNone (events.js:106:13)
+    at SMTPConnection.emit (events.js:208:7)
+    at SMTPConnection._actionEHLO (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:1133:14)
+    at SMTPConnection._processResponse (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:764:20)
+    at SMTPConnection._onData (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:570:14)
+    at TLSSocket._socket.on.chunk (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:522:47)
+    at emitOne (events.js:116:13)
+    at TLSSocket.emit (events.js:211:7)
+    at addChunk (_stream_readable.js:263:12)
+    at readableAddChunk (_stream_readable.js:250:11)
+    at TLSSocket.Readable.push (_stream_readable.js:208:10)
+    at TLSWrap.onread (net.js:601:20) code: 'EAUTH', command: 'API' }
+[Thu Nov 29 2018 16:41:53 GMT+0100 (WAT)] : { Error: Missing credentials for "PLAIN"
     at SMTPConnection._formatError (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:605:19)
     at SMTPConnection.login (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-connection/index.js:362:38)
     at connection.connect (/Users/fredrickadegoke/Documents/noldor-ah-backend/node_modules/nodemailer/lib/smtp-transport/index.js:270:32)

--- a/logs/info.log
+++ b/logs/info.log
@@ -291,6 +291,7 @@
 [Sun Nov 25 2018 02:38:32 GMT+0100 (WAT)] : 'This is just an info logger test'
 [Sun Nov 25 2018 02:38:32 GMT+0100 (WAT)] : 'This is just an info logger test'
 [Sun Nov 25 2018 02:38:32 GMT+0100 (WAT)] : 'This is just an info logger test'
+<<<<<<< HEAD
 [Tue Nov 27 2018 18:15:51 GMT+0100 (WAT)] : undefined
 [Tue Nov 27 2018 18:15:51 GMT+0100 (WAT)] : undefined
 [Tue Nov 27 2018 18:15:51 GMT+0100 (WAT)] : undefined
@@ -436,3 +437,217 @@
 [Thu Nov 29 2018 16:25:26 GMT+0100 (WAT)] : undefined
 [Thu Nov 29 2018 16:25:26 GMT+0100 (WAT)] : undefined
 [Thu Nov 29 2018 16:25:26 GMT+0100 (WAT)] : undefined
+=======
+[Wed Nov 28 2018 18:21:48 GMT+0100 (WAT)] : undefined
+[Wed Nov 28 2018 18:21:48 GMT+0100 (WAT)] : undefined
+[Wed Nov 28 2018 18:21:48 GMT+0100 (WAT)] : undefined
+[Wed Nov 28 2018 18:21:48 GMT+0100 (WAT)] : undefined
+[Wed Nov 28 2018 18:21:48 GMT+0100 (WAT)] : undefined
+[Wed Nov 28 2018 18:21:48 GMT+0100 (WAT)] : undefined
+[Wed Nov 28 2018 18:21:49 GMT+0100 (WAT)] : undefined
+[Wed Nov 28 2018 18:21:49 GMT+0100 (WAT)] : undefined
+[Wed Nov 28 2018 18:21:49 GMT+0100 (WAT)] : undefined
+[Wed Nov 28 2018 18:21:49 GMT+0100 (WAT)] : undefined
+[Wed Nov 28 2018 18:21:49 GMT+0100 (WAT)] : undefined
+[Wed Nov 28 2018 18:21:50 GMT+0100 (WAT)] : undefined
+[Wed Nov 28 2018 18:21:51 GMT+0100 (WAT)] : undefined
+[Wed Nov 28 2018 18:21:51 GMT+0100 (WAT)] : undefined
+[Wed Nov 28 2018 18:21:51 GMT+0100 (WAT)] : undefined
+[Wed Nov 28 2018 18:21:51 GMT+0100 (WAT)] : 'This is just an info logger test'
+[Wed Nov 28 2018 18:21:51 GMT+0100 (WAT)] : 'This is just an info logger test'
+[Wed Nov 28 2018 18:21:51 GMT+0100 (WAT)] : 'This is just an info logger test'
+[Wed Nov 28 2018 18:29:27 GMT+0100 (WAT)] : undefined
+[Wed Nov 28 2018 18:29:27 GMT+0100 (WAT)] : undefined
+[Wed Nov 28 2018 18:29:27 GMT+0100 (WAT)] : undefined
+[Wed Nov 28 2018 18:29:27 GMT+0100 (WAT)] : undefined
+[Wed Nov 28 2018 18:29:27 GMT+0100 (WAT)] : undefined
+[Wed Nov 28 2018 18:29:28 GMT+0100 (WAT)] : undefined
+[Wed Nov 28 2018 18:29:28 GMT+0100 (WAT)] : undefined
+[Wed Nov 28 2018 18:29:28 GMT+0100 (WAT)] : undefined
+[Wed Nov 28 2018 18:29:28 GMT+0100 (WAT)] : undefined
+[Wed Nov 28 2018 18:29:29 GMT+0100 (WAT)] : undefined
+[Wed Nov 28 2018 18:29:29 GMT+0100 (WAT)] : undefined
+[Wed Nov 28 2018 18:29:30 GMT+0100 (WAT)] : undefined
+[Wed Nov 28 2018 18:29:30 GMT+0100 (WAT)] : undefined
+[Wed Nov 28 2018 18:29:30 GMT+0100 (WAT)] : undefined
+[Wed Nov 28 2018 18:29:30 GMT+0100 (WAT)] : undefined
+[Wed Nov 28 2018 18:29:30 GMT+0100 (WAT)] : 'This is just an info logger test'
+[Wed Nov 28 2018 18:29:30 GMT+0100 (WAT)] : 'This is just an info logger test'
+[Wed Nov 28 2018 18:29:30 GMT+0100 (WAT)] : 'This is just an info logger test'
+[Wed Nov 28 2018 18:29:30 GMT+0100 (WAT)] : undefined
+[Wed Nov 28 2018 18:30:46 GMT+0100 (WAT)] : undefined
+[Wed Nov 28 2018 18:30:46 GMT+0100 (WAT)] : undefined
+[Wed Nov 28 2018 18:30:46 GMT+0100 (WAT)] : undefined
+[Wed Nov 28 2018 18:30:47 GMT+0100 (WAT)] : undefined
+[Wed Nov 28 2018 18:30:47 GMT+0100 (WAT)] : undefined
+[Wed Nov 28 2018 18:30:47 GMT+0100 (WAT)] : undefined
+[Wed Nov 28 2018 18:30:47 GMT+0100 (WAT)] : undefined
+[Wed Nov 28 2018 18:30:48 GMT+0100 (WAT)] : undefined
+[Wed Nov 28 2018 18:30:48 GMT+0100 (WAT)] : undefined
+[Wed Nov 28 2018 18:30:48 GMT+0100 (WAT)] : undefined
+[Wed Nov 28 2018 18:30:48 GMT+0100 (WAT)] : undefined
+[Wed Nov 28 2018 18:30:50 GMT+0100 (WAT)] : undefined
+[Wed Nov 28 2018 18:30:50 GMT+0100 (WAT)] : undefined
+[Wed Nov 28 2018 18:30:50 GMT+0100 (WAT)] : undefined
+[Wed Nov 28 2018 18:30:51 GMT+0100 (WAT)] : undefined
+[Wed Nov 28 2018 18:30:51 GMT+0100 (WAT)] : undefined
+[Wed Nov 28 2018 18:30:51 GMT+0100 (WAT)] : 'This is just an info logger test'
+[Wed Nov 28 2018 18:30:51 GMT+0100 (WAT)] : 'This is just an info logger test'
+[Wed Nov 28 2018 18:30:51 GMT+0100 (WAT)] : 'This is just an info logger test'
+[Wed Nov 28 2018 18:45:49 GMT+0100 (WAT)] : undefined
+[Wed Nov 28 2018 18:45:49 GMT+0100 (WAT)] : undefined
+[Wed Nov 28 2018 18:45:49 GMT+0100 (WAT)] : undefined
+[Wed Nov 28 2018 18:45:50 GMT+0100 (WAT)] : undefined
+[Wed Nov 28 2018 18:45:50 GMT+0100 (WAT)] : undefined
+[Wed Nov 28 2018 18:45:50 GMT+0100 (WAT)] : undefined
+[Wed Nov 28 2018 18:45:50 GMT+0100 (WAT)] : undefined
+[Wed Nov 28 2018 18:45:51 GMT+0100 (WAT)] : undefined
+[Wed Nov 28 2018 18:45:51 GMT+0100 (WAT)] : undefined
+[Wed Nov 28 2018 18:45:52 GMT+0100 (WAT)] : undefined
+[Wed Nov 28 2018 18:45:52 GMT+0100 (WAT)] : undefined
+[Wed Nov 28 2018 18:45:53 GMT+0100 (WAT)] : undefined
+[Wed Nov 28 2018 18:45:53 GMT+0100 (WAT)] : undefined
+[Wed Nov 28 2018 18:45:53 GMT+0100 (WAT)] : undefined
+[Wed Nov 28 2018 18:45:53 GMT+0100 (WAT)] : 'This is just an info logger test'
+[Wed Nov 28 2018 18:45:53 GMT+0100 (WAT)] : 'This is just an info logger test'
+[Wed Nov 28 2018 18:45:53 GMT+0100 (WAT)] : 'This is just an info logger test'
+[Wed Nov 28 2018 18:48:05 GMT+0100 (WAT)] : undefined
+[Wed Nov 28 2018 18:48:05 GMT+0100 (WAT)] : undefined
+[Wed Nov 28 2018 18:48:05 GMT+0100 (WAT)] : undefined
+[Wed Nov 28 2018 18:48:06 GMT+0100 (WAT)] : undefined
+[Wed Nov 28 2018 18:48:06 GMT+0100 (WAT)] : undefined
+[Wed Nov 28 2018 18:48:06 GMT+0100 (WAT)] : undefined
+[Wed Nov 28 2018 18:48:06 GMT+0100 (WAT)] : undefined
+[Wed Nov 28 2018 18:48:07 GMT+0100 (WAT)] : undefined
+[Wed Nov 28 2018 18:48:07 GMT+0100 (WAT)] : undefined
+[Wed Nov 28 2018 18:48:07 GMT+0100 (WAT)] : undefined
+[Wed Nov 28 2018 18:48:07 GMT+0100 (WAT)] : undefined
+[Wed Nov 28 2018 18:48:08 GMT+0100 (WAT)] : undefined
+[Wed Nov 28 2018 18:48:08 GMT+0100 (WAT)] : undefined
+[Wed Nov 28 2018 18:48:09 GMT+0100 (WAT)] : undefined
+[Wed Nov 28 2018 18:48:09 GMT+0100 (WAT)] : undefined
+[Wed Nov 28 2018 18:48:09 GMT+0100 (WAT)] : 'This is just an info logger test'
+[Wed Nov 28 2018 18:48:09 GMT+0100 (WAT)] : 'This is just an info logger test'
+[Wed Nov 28 2018 18:48:09 GMT+0100 (WAT)] : 'This is just an info logger test'
+[Wed Nov 28 2018 18:48:09 GMT+0100 (WAT)] : undefined
+[Wed Nov 28 2018 18:48:31 GMT+0100 (WAT)] : undefined
+[Wed Nov 28 2018 18:48:31 GMT+0100 (WAT)] : undefined
+[Wed Nov 28 2018 18:48:31 GMT+0100 (WAT)] : undefined
+[Wed Nov 28 2018 18:48:31 GMT+0100 (WAT)] : undefined
+[Wed Nov 28 2018 18:48:31 GMT+0100 (WAT)] : undefined
+[Wed Nov 28 2018 18:48:31 GMT+0100 (WAT)] : undefined
+[Wed Nov 28 2018 18:48:32 GMT+0100 (WAT)] : undefined
+[Wed Nov 28 2018 18:48:32 GMT+0100 (WAT)] : undefined
+[Wed Nov 28 2018 18:48:32 GMT+0100 (WAT)] : undefined
+[Wed Nov 28 2018 18:48:32 GMT+0100 (WAT)] : undefined
+[Wed Nov 28 2018 18:48:33 GMT+0100 (WAT)] : undefined
+[Wed Nov 28 2018 18:48:34 GMT+0100 (WAT)] : undefined
+[Wed Nov 28 2018 18:48:34 GMT+0100 (WAT)] : undefined
+[Wed Nov 28 2018 18:48:34 GMT+0100 (WAT)] : undefined
+[Wed Nov 28 2018 18:48:34 GMT+0100 (WAT)] : undefined
+[Wed Nov 28 2018 18:48:35 GMT+0100 (WAT)] : undefined
+[Wed Nov 28 2018 18:48:35 GMT+0100 (WAT)] : 'This is just an info logger test'
+[Wed Nov 28 2018 18:48:35 GMT+0100 (WAT)] : 'This is just an info logger test'
+[Wed Nov 28 2018 18:48:35 GMT+0100 (WAT)] : 'This is just an info logger test'
+[Wed Nov 28 2018 18:48:35 GMT+0100 (WAT)] : undefined
+[Wed Nov 28 2018 18:49:08 GMT+0100 (WAT)] : undefined
+[Wed Nov 28 2018 18:49:08 GMT+0100 (WAT)] : undefined
+[Wed Nov 28 2018 18:49:08 GMT+0100 (WAT)] : undefined
+[Wed Nov 28 2018 18:49:08 GMT+0100 (WAT)] : undefined
+[Wed Nov 28 2018 18:49:09 GMT+0100 (WAT)] : undefined
+[Wed Nov 28 2018 18:49:09 GMT+0100 (WAT)] : undefined
+[Wed Nov 28 2018 18:49:09 GMT+0100 (WAT)] : undefined
+[Wed Nov 28 2018 18:49:10 GMT+0100 (WAT)] : undefined
+[Wed Nov 28 2018 18:49:10 GMT+0100 (WAT)] : undefined
+[Wed Nov 28 2018 18:49:10 GMT+0100 (WAT)] : undefined
+[Wed Nov 28 2018 18:49:10 GMT+0100 (WAT)] : undefined
+[Wed Nov 28 2018 18:49:11 GMT+0100 (WAT)] : undefined
+[Wed Nov 28 2018 18:49:11 GMT+0100 (WAT)] : undefined
+[Wed Nov 28 2018 18:49:11 GMT+0100 (WAT)] : undefined
+[Wed Nov 28 2018 18:49:12 GMT+0100 (WAT)] : undefined
+[Wed Nov 28 2018 18:49:12 GMT+0100 (WAT)] : undefined
+[Wed Nov 28 2018 18:49:12 GMT+0100 (WAT)] : 'This is just an info logger test'
+[Wed Nov 28 2018 18:49:12 GMT+0100 (WAT)] : 'This is just an info logger test'
+[Wed Nov 28 2018 18:49:12 GMT+0100 (WAT)] : 'This is just an info logger test'
+[Wed Nov 28 2018 18:50:04 GMT+0100 (WAT)] : undefined
+[Wed Nov 28 2018 18:50:04 GMT+0100 (WAT)] : undefined
+[Wed Nov 28 2018 18:50:04 GMT+0100 (WAT)] : undefined
+[Wed Nov 28 2018 18:50:04 GMT+0100 (WAT)] : undefined
+[Wed Nov 28 2018 18:50:05 GMT+0100 (WAT)] : undefined
+[Wed Nov 28 2018 18:50:05 GMT+0100 (WAT)] : undefined
+[Wed Nov 28 2018 18:50:05 GMT+0100 (WAT)] : undefined
+[Wed Nov 28 2018 18:50:05 GMT+0100 (WAT)] : undefined
+[Wed Nov 28 2018 18:50:06 GMT+0100 (WAT)] : undefined
+[Wed Nov 28 2018 18:50:06 GMT+0100 (WAT)] : undefined
+[Wed Nov 28 2018 18:50:06 GMT+0100 (WAT)] : undefined
+[Wed Nov 28 2018 18:50:07 GMT+0100 (WAT)] : undefined
+[Wed Nov 28 2018 18:50:07 GMT+0100 (WAT)] : undefined
+[Wed Nov 28 2018 18:50:07 GMT+0100 (WAT)] : undefined
+[Wed Nov 28 2018 18:50:08 GMT+0100 (WAT)] : undefined
+[Wed Nov 28 2018 18:50:08 GMT+0100 (WAT)] : undefined
+[Wed Nov 28 2018 18:50:08 GMT+0100 (WAT)] : 'This is just an info logger test'
+[Wed Nov 28 2018 18:50:08 GMT+0100 (WAT)] : 'This is just an info logger test'
+[Wed Nov 28 2018 18:50:08 GMT+0100 (WAT)] : 'This is just an info logger test'
+[Wed Nov 28 2018 18:51:43 GMT+0100 (WAT)] : undefined
+[Wed Nov 28 2018 18:51:43 GMT+0100 (WAT)] : undefined
+[Wed Nov 28 2018 18:51:43 GMT+0100 (WAT)] : undefined
+[Wed Nov 28 2018 18:51:43 GMT+0100 (WAT)] : undefined
+[Wed Nov 28 2018 18:51:43 GMT+0100 (WAT)] : undefined
+[Wed Nov 28 2018 18:51:43 GMT+0100 (WAT)] : undefined
+[Wed Nov 28 2018 18:51:44 GMT+0100 (WAT)] : undefined
+[Wed Nov 28 2018 18:51:44 GMT+0100 (WAT)] : undefined
+[Wed Nov 28 2018 18:51:44 GMT+0100 (WAT)] : undefined
+[Wed Nov 28 2018 18:51:44 GMT+0100 (WAT)] : undefined
+[Wed Nov 28 2018 18:51:45 GMT+0100 (WAT)] : undefined
+[Wed Nov 28 2018 18:51:46 GMT+0100 (WAT)] : undefined
+[Wed Nov 28 2018 18:51:46 GMT+0100 (WAT)] : undefined
+[Wed Nov 28 2018 18:51:46 GMT+0100 (WAT)] : undefined
+[Wed Nov 28 2018 18:51:46 GMT+0100 (WAT)] : undefined
+[Wed Nov 28 2018 18:51:46 GMT+0100 (WAT)] : undefined
+[Wed Nov 28 2018 18:51:46 GMT+0100 (WAT)] : 'This is just an info logger test'
+[Wed Nov 28 2018 18:51:46 GMT+0100 (WAT)] : 'This is just an info logger test'
+[Wed Nov 28 2018 18:51:46 GMT+0100 (WAT)] : 'This is just an info logger test'
+[Wed Nov 28 2018 18:52:37 GMT+0100 (WAT)] : undefined
+[Wed Nov 28 2018 18:52:37 GMT+0100 (WAT)] : undefined
+[Wed Nov 28 2018 18:52:37 GMT+0100 (WAT)] : undefined
+[Wed Nov 28 2018 18:52:37 GMT+0100 (WAT)] : undefined
+[Wed Nov 28 2018 18:52:38 GMT+0100 (WAT)] : undefined
+[Wed Nov 28 2018 18:52:38 GMT+0100 (WAT)] : undefined
+[Wed Nov 28 2018 18:52:38 GMT+0100 (WAT)] : undefined
+[Wed Nov 28 2018 18:52:38 GMT+0100 (WAT)] : undefined
+[Wed Nov 28 2018 18:52:39 GMT+0100 (WAT)] : undefined
+[Wed Nov 28 2018 18:52:39 GMT+0100 (WAT)] : undefined
+[Wed Nov 28 2018 18:52:39 GMT+0100 (WAT)] : undefined
+[Wed Nov 28 2018 18:52:40 GMT+0100 (WAT)] : undefined
+[Wed Nov 28 2018 18:52:40 GMT+0100 (WAT)] : undefined
+[Wed Nov 28 2018 18:52:40 GMT+0100 (WAT)] : undefined
+[Wed Nov 28 2018 18:52:41 GMT+0100 (WAT)] : undefined
+[Wed Nov 28 2018 18:52:41 GMT+0100 (WAT)] : undefined
+[Wed Nov 28 2018 18:52:41 GMT+0100 (WAT)] : 'This is just an info logger test'
+[Wed Nov 28 2018 18:52:41 GMT+0100 (WAT)] : 'This is just an info logger test'
+[Wed Nov 28 2018 18:52:41 GMT+0100 (WAT)] : 'This is just an info logger test'
+>>>>>>> bug(reactivate user): Allow user reactivate account
+[Thu Nov 29 2018 16:41:49 GMT+0100 (WAT)] : undefined
+[Thu Nov 29 2018 16:41:49 GMT+0100 (WAT)] : undefined
+[Thu Nov 29 2018 16:41:49 GMT+0100 (WAT)] : undefined
+[Thu Nov 29 2018 16:41:49 GMT+0100 (WAT)] : undefined
+[Thu Nov 29 2018 16:41:50 GMT+0100 (WAT)] : undefined
+[Thu Nov 29 2018 16:41:50 GMT+0100 (WAT)] : undefined
+[Thu Nov 29 2018 16:41:50 GMT+0100 (WAT)] : undefined
+[Thu Nov 29 2018 16:41:50 GMT+0100 (WAT)] : undefined
+[Thu Nov 29 2018 16:41:50 GMT+0100 (WAT)] : undefined
+[Thu Nov 29 2018 16:41:51 GMT+0100 (WAT)] : undefined
+[Thu Nov 29 2018 16:41:51 GMT+0100 (WAT)] : undefined
+[Thu Nov 29 2018 16:41:52 GMT+0100 (WAT)] : undefined
+[Thu Nov 29 2018 16:41:52 GMT+0100 (WAT)] : undefined
+[Thu Nov 29 2018 16:41:52 GMT+0100 (WAT)] : undefined
+[Thu Nov 29 2018 16:41:53 GMT+0100 (WAT)] : undefined
+[Thu Nov 29 2018 16:41:53 GMT+0100 (WAT)] : undefined
+[Thu Nov 29 2018 16:41:53 GMT+0100 (WAT)] : 'This is just an info logger test'
+[Thu Nov 29 2018 16:41:53 GMT+0100 (WAT)] : 'This is just an info logger test'
+[Thu Nov 29 2018 16:41:53 GMT+0100 (WAT)] : 'This is just an info logger test'
+[Thu Nov 29 2018 16:41:53 GMT+0100 (WAT)] : undefined
+[Thu Nov 29 2018 16:41:53 GMT+0100 (WAT)] : undefined
+[Thu Nov 29 2018 16:41:53 GMT+0100 (WAT)] : undefined
+[Thu Nov 29 2018 16:41:53 GMT+0100 (WAT)] : undefined
+[Thu Nov 29 2018 16:41:53 GMT+0100 (WAT)] : undefined

--- a/server/src/test/integrationTests/adminTest.js
+++ b/server/src/test/integrationTests/adminTest.js
@@ -167,7 +167,23 @@ describe('Admin Functionality Tests', () => {
           done();
         });
     });
-
+    it('should disallow user login', (done) => {
+      const values = {
+        email: 'mama@smurf.com',
+        password: 'BigBlue5ky'
+      };
+      chai.request(app)
+        .post('/api/v1/users/login')
+        .send(values)
+        .end((err, res) => {
+          if (err) done(err);
+          expect(res.status).to.equal(403);
+          expect(res.body.success).to.equal(false);
+          // eslint-disable-next-line max-len
+          expect(res.body.message).to.equal('Your account has been deactivated by the admin, please contact them for more details.');
+          done();
+        });
+    });
     it('should return a 404 if user does not exist (reactivation)', (done) => {
       chai.request(app)
         .put('/api/v1/admin/reactivate/users/babysmurf')


### PR DESCRIPTION
#### What does this PR do?
* When a user deactivates their account when they should be reactivated, should they try to log in again.
#### Description of Task to be completed?
- allow a user who has been deleted to login/reactivate account
- disallow users deactivated by the admin from logging into the platform.
#### How should this be manually tested?
- Deactivate a user by visiting `http://localhost:3000/api/v1/users/:userId/deactivate` on the postman.
- Simply reactivate the same user by logging in the user 'http://localhost:3000/api/v1/users/login'
#### Any background context you want to provide?
* When a user is deactivated, we want to make it easy for the user to come onboard again. without having to signup or any extra hassle. But if the user is deactivated by the admin due to a violation of any of our policies, disallow that user from logging in.
#### What are the relevant pivotal tracker stories?
#162150225
#### Screenshots (if appropriate)
<img width="1440" alt="screen shot 2018-11-28 at 7 22 23 pm" src="https://user-images.githubusercontent.com/26186206/49173071-f5adcf80-f342-11e8-914f-7878dfe01bb9.png">

#### Questions:
N/A