### PR TITLE
#162483814 Fix Index Buffer Overflow

### DIFF
--- a/server/src/db/migrations/d-create-search-trigger.js
+++ b/server/src/db/migrations/d-create-search-trigger.js
@@ -12,9 +12,7 @@ export default {
       .then(() => sequelize
         .query(`UPDATE "${tableName}" SET "${columnName}" = to_tsvector('english', title || ' ' || content )`)
         .then(() => sequelize
-          .query(`CREATE INDEX searchIndex ON "${tableName}" ("${columnName}");`)
-          .then(() => sequelize
-            .query(`CREATE TRIGGER updateSearchIndex BEFORE INSERT OR UPDATE ON "${tableName}" FOR EACH ROW EXECUTE PROCEDURE tsvector_update_trigger("${columnName}", 'pg_catalog.english', ${searchFields.join(', ')})`))));
+          .query(`CREATE TRIGGER updateSearchIndex BEFORE INSERT OR UPDATE ON "${tableName}" FOR EACH ROW EXECUTE PROCEDURE tsvector_update_trigger("${columnName}", 'pg_catalog.english', ${searchFields.join(', ')})`)));
   },
 
   down: (queryInterface) => {
@@ -22,8 +20,6 @@ export default {
 
     return sequelize
       .query(`DROP TRIGGER updateSearchIndex ON "${tableName}"`)
-      .then(() => sequelize
-        .query('DROP INDEX searchIndex'))
       .then(() => sequelize
         .query(`ALTER TABLE "${tableName}" DROP COLUMN "${columnName}"`));
   },


### PR DESCRIPTION
#### What does this PR do?
When creating a long article, the size required to store the index on that article is larger than the default provided for b-tree indexes.

This PR fixes that.

#### Description of task to be completed
- remove index on searchIndex column

#### How should this be manually tested?
- Create an article with a word count of more than 2000
- The article should be posted successfully

#### Any background context you want to provide?
An index was formally added to the searchIndex column to speed up search queries. The index has to be removed because the limit on free databases by Heroku is not large enough to handle large indexes.

#### What are the relevant pivotal tracker stories?
#162483814

#### Screenshots (if appropriate)
N/A

#### Questions
N/A