### PR TITLE
#162576218 Article Pagination Bugfix

### DIFF
--- a/server/src/controllers/SocialMediaLogin.js
+++ b/server/src/controllers/SocialMediaLogin.js
@@ -1,9 +1,4 @@
 import issueToken from '../helpers/issueToken';
-import httpResponse from '../helpers/response';
-
-const {
-  goodResponse
-} = httpResponse;
 
 /**
  * @class { Social media controller that returns a token to the user }
@@ -19,7 +14,14 @@ class SocialMedia {
     const { user } = req;
     const token = issueToken(user);
     res.header('x-token', token);
-    return goodResponse(res, 200, 'Facebook login successful', user, token);
+    return res.status(200).json({
+      success: true,
+      message: 'Facebook login successful',
+      data: {
+        user,
+        token
+      }
+    });
   }
 
   /**
@@ -31,7 +33,14 @@ class SocialMedia {
     const { user } = req;
     const token = issueToken(user);
     res.header('x-token', token);
-    return goodResponse(res, 200, 'Google login successful', user, token);
+    return res.status(200).json({
+      success: true,
+      message: 'Google login successful',
+      data: {
+        user,
+        token
+      }
+    });
   }
 }
 

--- a/server/src/controllers/paginationController.js
+++ b/server/src/controllers/paginationController.js
@@ -16,9 +16,9 @@ class PaginatorController {
      * @var {number} limit per page
      * @var {limit} offSet page skip
    */
-    const { Article } = model;
+    const { Article, User } = model;
     const page = parseInt(req.params.source, 10);
-    const limit = 3;
+    const limit = parseInt(req.params.limit, 10);
     if (page === 0 || page < 0) {
       return res.status(404).json({
         message: 'Page number must be numeric and greater than zero'
@@ -44,7 +44,10 @@ class PaginatorController {
       ],
       where: {
         published: true
-      }
+      },
+      include: [{
+        model: User, attributes: ['username', 'bio', 'avatarUrl']
+      }]
     })
       .then((data) => {
         if (data.count === 0) {

--- a/server/src/routes/api/article.js
+++ b/server/src/routes/api/article.js
@@ -29,7 +29,7 @@ router.post('/articles', authorization, isVerified, tagsValidation, postArticle)
 router.put('/articles/:slug/publish', authorization, isVerified, publishArticle);
 router.put('/articles/:slug', authorization, isVerified, tagsValidation, updateArticle);
 router.delete('/articles/:slug', authorization, isVerified, deleteArticle);
-router.get('/articles/page/:source', Paginator.page);
+router.get('/articles/limit/:limit/page/:source', Paginator.page);
 router.post('/articles/:slug/likes', authorization, isVerified, ReactionController.likeArticle);
 router.post('/articles/ratings/:articleId', authorization, isVerified, rateArticles);
 

--- a/server/src/test/integrationTests/paginationTest.js
+++ b/server/src/test/integrationTests/paginationTest.js
@@ -47,7 +47,7 @@ describe('GET all articles endpoint', () => {
   });
   it('Should return 200 for successful pagination', (done) => {
     chai.request(app)
-      .get('/api/v1/articles/page/1')
+      .get('/api/v1/articles/limit/1/page/1')
       .end((error, response) => {
         if (error) done(error);
         expect(response.status).to.equal(200);


### PR DESCRIPTION
#### What does this PR do?
- Fixes static article limit on number of returned articles by making it dynamic
- Fixes missing author details on return article response object

#### Description of the task to be completed
- Write tests
- Modify article pagination route URL to account for page article limit parameter
- Include article author details to the response object
- Modify pagination controller to account for page limit

#### How should this be manually tested?
- Clone the repo to local machine
- Run `npm install` to install dependencies
- Run postman and visit the URL `localhost:3000/api/v1/articles/limit/:limit/page/:page` using a GET verb
- Enter a numeric value for the limit and page.

#### Any background context you want to provide?
None

#### What are the relevant pivotal tracker stories?
#162576218

#### Screenshots (if appropriate)

![image](https://user-images.githubusercontent.com/32770340/49803472-38fb3b80-fd50-11e8-8375-ac4af08acd08.png)

![image](https://user-images.githubusercontent.com/32770340/49803478-3f89b300-fd50-11e8-9515-c76b07f30f67.png)

![image](https://user-images.githubusercontent.com/32770340/49803485-444e6700-fd50-11e8-9341-e3b0c3a3ae89.png)
